### PR TITLE
Made ncCheck argument file 'const char*'

### DIFF
--- a/cxx4/ncCheck.cpp
+++ b/cxx4/ncCheck.cpp
@@ -7,7 +7,7 @@ using namespace netCDF::exceptions;
 namespace netCDF
 {
   // function checks error code and if necessary throws appropriate exception.
-  void ncCheck(int retCode,char* file,int line){
+  void ncCheck(int retCode, const char* file, int line){
     switch(retCode) {
       
     case NC_NOERR           : return; /* No Error */

--- a/cxx4/ncCheck.h
+++ b/cxx4/ncCheck.h
@@ -13,7 +13,7 @@ namespace netCDF
     \param file    The name of the file from which this call originates.
     \param line    The line number in the file from which this call originates.
   */
-  void ncCheck(int retCode,char* file,int line);
+  void ncCheck(int retCode, const char* file, int line);
 
 };
 


### PR DESCRIPTION
This removes a lot of compiler warnings (g++) as mentioned in NCXXF-4.
