### PR TITLE
Fixed bug in test of compound type fill value

### DIFF
--- a/cxx4/test_type.cpp
+++ b/cxx4/test_type.cpp
@@ -416,7 +416,7 @@ try
       dummyStruct2[0].mem3[1]=-6;
       dummyStruct2[0].mem3[2]=20;
       
-      var_3.setFill(true,&dummyFill);
+      var_3.setFill(true,dummyFill);
 
       vector<size_t> index(1);index[0]=1;
       //var_3.putVar(&dummyStruct2);  


### PR DESCRIPTION
test_type was failing due to an incorrectly call to NcVar::setFill.

In the original code the result was a call to template<class T> NcVar::setFill(bool, T) witt T=struct3*, which resulted in the address of the fill value being copied instead of the value.
