### PR TITLE
Nc file copy assign

### DIFF
--- a/cxx4/ncFile.cpp
+++ b/cxx4/ncFile.cpp
@@ -15,11 +15,6 @@ NcFile::~NcFile()
   ncCheck(nc_close(myId),__FILE__,__LINE__);
 }
 
-/*//! The copy constructor.
-NcFile::NcFile(const NcGroup& rhs):
-    NcGroup(rhs)                   // intialize base class parts
-{}*/
-
 // Constructor generates a null object.
 NcFile::NcFile() : 
     NcGroup()  // invoke base class constructor

--- a/cxx4/ncFile.h
+++ b/cxx4/ncFile.h
@@ -63,6 +63,9 @@ namespace netCDF
       virtual ~NcFile(); //closes file and releases all resources
 
    private:
+	   /* Do not allow definition of NcFile involving copying any NcFile or NcGroup.
+		  Because the destructor closes the file and releases al resources such 
+		  an action could leave NcFile objects in an invalid state */
 	   NcFile& operator =(const NcGroup & rhs);
 	   NcFile& operator =(const NcFile & rhs);
 	   NcFile(const NcGroup& rhs);


### PR DESCRIPTION
The NcFile destructor will close the file and release all resources. If any NcFile object is copied and either copy runs out of scope the remaining object will be left in an invalid state with no underlying netcdf-c resources, but isNull() will still return false.

The suggested fix is to simply not allow any NcFile object to be copy constructed or assigned.
