### PR TITLE
Fix multilib and underlinking problems in pkg-config files

### DIFF
--- a/ncxx4-config.in
+++ b/ncxx4-config.in
@@ -5,7 +5,7 @@
 
 prefix=@prefix@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=@libdir@
 includedir=${prefix}/include
 
 cc="@CC@"
@@ -13,7 +13,7 @@ cxx="@CXX@"
 fc="@FC@"
 cflags=" -I${includedir} @CPPFLAGS@" 
 fflags="@FFLAGS@ @MOD_FLAG@${includedir}"
-libs="-L${libdir} @NC_LIBS@"
+libs="-L${libdir} @NC_LIBS@ -lnetcdf"
 flibs="-L${libdir} @NC_FLIBS@"
 has_dap="@HAS_DAP@"
 has_nc2="@HAS_NC2@"

--- a/netcdf-cxx4.pc.in
+++ b/netcdf-cxx4.pc.in
@@ -10,4 +10,4 @@ Description: NetCDF C++ Client Library
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} @NC_LIBS@
 Cflags: -I${includedir}
-
+Requires: netcdf


### PR DESCRIPTION
- Using @libdir@ instead of hardcoding .../lib allows mor flexibility for
  downstream projects
- Projects need to link against libnetcdf in addition

Signed-off-by: Justin Lecher jlec@gentoo.org
