### PR TITLE
Do not call nc_close on null object in NcFile destructor

### DIFF
--- a/cxx4/ncFile.cpp
+++ b/cxx4/ncFile.cpp
@@ -17,7 +17,8 @@ NcFile::~NcFile()
   // causes undefined behaviour! so just printing a warning message
   try
   {
-    ncCheck(nc_close(myId),__FILE__,__LINE__);
+    if (!nullObject)
+      ncCheck(nc_close(myId),__FILE__,__LINE__);
   }
   catch (NcException &e) 
   {


### PR DESCRIPTION
This will remove the error message from destruction of declared NcFile objects: https://bugtracking.unidata.ucar.edu/browse/NCCPP-6
