### PR TITLE
Minor code clean-up

### DIFF
--- a/cxx4/ncAtt.h
+++ b/cxx4/ncAtt.h
@@ -1,10 +1,10 @@
+#ifndef NcAttClass
+#define NcAttClass
+
 #include "ncType.h"
 #include "ncException.h"
 #include <string>
 #include <typeinfo>
-
-#ifndef NcAttClass
-#define NcAttClass
 
 namespace netCDF
 {
@@ -21,7 +21,7 @@ namespace netCDF
     NcAtt ();
     
     /*! Constructor for non-null instances. */
-    NcAtt(bool nullObject); 
+    explicit NcAtt(bool nullObject); 
 
     /*! The copy constructor. */
     NcAtt(const NcAtt& rhs);

--- a/cxx4/ncByte.h
+++ b/cxx4/ncByte.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcByteClass
 #define NcByteClass
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncChar.h
+++ b/cxx4/ncChar.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcCharClass
 #define NcCharClass
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncCheck.h
+++ b/cxx4/ncCheck.h
@@ -1,9 +1,9 @@
+#ifndef NcCheckFunction
+#define NcCheckFunction
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-
-#ifndef NcCheckFunction
-#define NcCheckFunction
 
 namespace netCDF
 {

--- a/cxx4/ncCompoundType.cpp
+++ b/cxx4/ncCompoundType.cpp
@@ -1,6 +1,6 @@
+#include "ncCompoundType.h"
 #include "ncGroup.h"
 #include "ncCheck.h"
-#include "ncCompoundType.h"
 #include "ncByte.h"
 #include "ncUbyte.h"
 #include "ncChar.h"

--- a/cxx4/ncCompoundType.h
+++ b/cxx4/ncCompoundType.h
@@ -1,11 +1,10 @@
+#ifndef NcCompoundTypeClass
+#define NcCompoundTypeClass
+
 #include <string>
 #include <vector>
 #include "ncType.h"
 #include "netcdf.h"
-
-#ifndef NcCompoundTypeClass
-#define NcCompoundTypeClass
-
 
 namespace netCDF
 {

--- a/cxx4/ncDim.h
+++ b/cxx4/ncDim.h
@@ -1,9 +1,8 @@
-#include <string>
-#include "netcdf.h"
-
 #ifndef NcDimClass
 #define NcDimClass
 
+#include <string>
+#include "netcdf.h"
 
 namespace netCDF
 {

--- a/cxx4/ncDouble.h
+++ b/cxx4/ncDouble.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcDoubleClass
 #define NcDoubleClass
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncEnumType.h
+++ b/cxx4/ncEnumType.h
@@ -1,11 +1,10 @@
+#ifndef NcEnumTypeClass
+#define NcEnumTypeClass
+
 #include <string>
 #include "ncType.h"
 #include "netcdf.h"
 #include "ncCheck.h"
-
-#ifndef NcEnumTypeClass
-#define NcEnumTypeClass
-
 
 namespace netCDF
 {

--- a/cxx4/ncException.cpp
+++ b/cxx4/ncException.cpp
@@ -54,7 +54,7 @@ NcException::NcException(int errorCode, const char* complaint,const char* fileNa
   }
 }
 
-NcException::NcException(const NcException& e) throw()
+NcException::NcException(const NcException& e)
 	: what_msg(NULL)
   , ec(e.ec)
 {
@@ -65,7 +65,7 @@ NcException::NcException(const NcException& e) throw()
 	}
 }
 
-NcException& NcException::operator=(const NcException& e) throw(){
+NcException& NcException::operator=(const NcException& e) {
 	if (this != &e){
     ec = e.ec;
 		delete what_msg;
@@ -78,7 +78,7 @@ NcException& NcException::operator=(const NcException& e) throw(){
 	return *this;
 }
 
-NcException::~NcException()throw() {
+NcException::~NcException() throw() {
 	delete what_msg;
 }
 
@@ -88,7 +88,7 @@ const char* NcException::what() const throw()
   return what_msg==NULL ? "" : what_msg->c_str();
 }
 
-int NcException::errorCode() const throw() {
+int NcException::errorCode() const {
   return ec;
 }
 

--- a/cxx4/ncException.h
+++ b/cxx4/ncException.h
@@ -1,9 +1,9 @@
+#ifndef NcExceptionClasses
+#define NcExceptionClasses
+
 #include <exception>
 #include <string>
 #include <iostream>
-
-#ifndef NcExceptionClasses
-#define NcExceptionClasses
 
 namespace netCDF
 {
@@ -26,11 +26,11 @@ namespace netCDF
       //NcException(const string& complaint,const char* fileName,int lineNumber);
       NcException(const char* complaint,const char* fileName,int lineNumber);
       NcException(int errorCode, const char* complaint,const char* fileName,int lineNumber);
-      NcException(const NcException& e) throw();
-      NcException& operator=(const NcException& e) throw();
+      NcException(const NcException& e);
+      NcException& operator=(const NcException& e);
       virtual ~NcException() throw();
       const char* what() const throw();
-      int errorCode() const throw();
+      int errorCode() const;
     private:
       std::string* what_msg;
       int ec;

--- a/cxx4/ncFile.h
+++ b/cxx4/ncFile.h
@@ -1,10 +1,9 @@
-#include <string>
-#include "ncGroup.h"
-#include "netcdf.h"
-
 #ifndef NcFileClass
 #define NcFileClass
 
+#include <string>
+#include "ncGroup.h"
+#include "netcdf.h"
 
 //!  C++ API for netCDF4.
 namespace netCDF
@@ -70,7 +69,7 @@ namespace netCDF
 
    private:
 	   /* Do not allow definition of NcFile involving copying any NcFile or NcGroup.
-		  Because the destructor closes the file and releases al resources such 
+		  Because the destructor closes the file and releases all resources such 
 		  an action could leave NcFile objects in an invalid state */
 	   NcFile& operator =(const NcGroup & rhs);
 	   NcFile& operator =(const NcFile & rhs);

--- a/cxx4/ncFloat.h
+++ b/cxx4/ncFloat.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcFloatClass
 #define NcFloatClass
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncGroup.h
+++ b/cxx4/ncGroup.h
@@ -1,3 +1,6 @@
+#ifndef NcGroupClass
+#define NcGroupClass
+
 #include <string>
 #include <vector>
 #include <set>
@@ -5,12 +8,6 @@
 #include "ncType.h"
 #include "ncEnumType.h"
 #include "ncGroupAtt.h"
-
-
-
-#ifndef NcGroupClass
-#define NcGroupClass
-
 
 namespace netCDF
 {

--- a/cxx4/ncGroupAtt.h
+++ b/cxx4/ncGroupAtt.h
@@ -1,8 +1,8 @@
-#include "ncAtt.h"
-#include "netcdf.h"
-
 #ifndef NcGroupAttClass
 #define NcGroupAttClass
+
+#include "ncAtt.h"
+#include "netcdf.h"
 
 namespace netCDF
 {

--- a/cxx4/ncInt.h
+++ b/cxx4/ncInt.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcIntClass
 #define NcIntClass
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncInt64.h
+++ b/cxx4/ncInt64.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcInt64Class
 #define NcInt64Class
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncOpaqueType.cpp
+++ b/cxx4/ncOpaqueType.cpp
@@ -7,9 +7,7 @@ using namespace std;
 using namespace netCDF;
 using namespace netCDF::exceptions;
 
-// Class represents a netCDF variable.
-using namespace netCDF;
-  
+
 // assignment operator
 NcOpaqueType& NcOpaqueType::operator=(const NcOpaqueType& rhs)
 {

--- a/cxx4/ncOpaqueType.h
+++ b/cxx4/ncOpaqueType.h
@@ -1,10 +1,9 @@
-#include <string>
-#include "ncType.h"
-#include "netcdf.h"
-
 #ifndef NcOpaqueTypeClass
 #define NcOpaqueTypeClass
 
+#include <string>
+#include "ncType.h"
+#include "netcdf.h"
 
 namespace netCDF
 {

--- a/cxx4/ncShort.h
+++ b/cxx4/ncShort.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcShortClass
 #define NcShortClass
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncString.h
+++ b/cxx4/ncString.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcStringClass
 #define NcStringClass
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncType.cpp
+++ b/cxx4/ncType.cpp
@@ -1,5 +1,5 @@
-#include <string>
 #include "ncType.h"
+#include <string>
 #include "ncGroup.h"
 #include "ncCheck.h"
 using namespace std;

--- a/cxx4/ncType.h
+++ b/cxx4/ncType.h
@@ -1,8 +1,8 @@
-#include <string>
-#include "netcdf.h"
-
 #ifndef NcTypeClass
 #define NcTypeClass
+
+#include <string>
+#include "netcdf.h"
 
 
 namespace netCDF

--- a/cxx4/ncUbyte.h
+++ b/cxx4/ncUbyte.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcUbyteClass
 #define NcUbyteClass
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncUint.h
+++ b/cxx4/ncUint.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcUintClass
 #define NcUintClass
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncUint64.h
+++ b/cxx4/ncUint64.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcUint64Class
 #define NcUint64Class
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncUshort.h
+++ b/cxx4/ncUshort.h
@@ -1,7 +1,7 @@
-#include "ncType.h"
-
 #ifndef NcUshortClass
 #define NcUshortClass
+
+#include "ncType.h"
 
 namespace netCDF
 {

--- a/cxx4/ncVar.cpp
+++ b/cxx4/ncVar.cpp
@@ -1,6 +1,6 @@
+#include "ncVar.h"
 #include "ncVarAtt.h"
 #include "ncDim.h"
-#include "ncVar.h"
 #include "ncGroup.h"
 #include "ncCheck.h"
 #include "ncException.h"

--- a/cxx4/ncVar.h
+++ b/cxx4/ncVar.h
@@ -1,3 +1,6 @@
+#ifndef NcVarClass
+#define NcVarClass
+
 #include <exception>
 #include <string>
 #include <typeinfo>
@@ -18,9 +21,6 @@
 #include "ncFloat.h"
 #include "ncDouble.h"
 #include "ncString.h"
-
-#ifndef NcVarClass
-#define NcVarClass
 
 namespace netCDF
 {

--- a/cxx4/ncVarAtt.cpp
+++ b/cxx4/ncVarAtt.cpp
@@ -1,5 +1,5 @@
-#include "ncVar.h"
 #include "ncVarAtt.h"
+#include "ncVar.h"
 #include "ncGroup.h"
 #include "ncCheck.h"
 #include <netcdf.h>

--- a/cxx4/ncVarAtt.h
+++ b/cxx4/ncVarAtt.h
@@ -1,8 +1,8 @@
-#include "ncAtt.h"
-#include "netcdf.h"
-
 #ifndef NcVarAttClass
 #define NcVarAttClass
+
+#include "ncAtt.h"
+#include "netcdf.h"
 
 namespace netCDF
 {

--- a/cxx4/ncVlenType.cpp
+++ b/cxx4/ncVlenType.cpp
@@ -19,8 +19,6 @@ using namespace std;
 using namespace netCDF;
 using namespace netCDF::exceptions;
 
-// Class represents a netCDF variable.
-using namespace netCDF;
 
 // assignment operator
 NcVlenType& NcVlenType::operator=(const NcVlenType& rhs)

--- a/cxx4/ncVlenType.h
+++ b/cxx4/ncVlenType.h
@@ -1,9 +1,9 @@
+#ifndef NcVlenTypeClass
+#define NcVlenTypeClass
+
 #include <string>
 #include "ncType.h"
 #include "netcdf.h"
-
-#ifndef NcVlenTypeClass
-#define NcVlenTypeClass
 
 
 namespace netCDF


### PR DESCRIPTION
Minor changes to make the code a cleaner base for development..

1: All include guards are moved to the top of the header files.
2: Header file X.h is included first in X.cpp. Easier to detect missing includes in X.h.
3: Throw specifications are deprecated in C++11, so I've removed throw() in NcException. The destructor and what() function still needs 'throw()' for gcc compilation.
4: Removed a couple of unnecessary using namespace declarations.
5: Made single argument constructor NcAtt(bool) explicit. To avoid unintentional implicit conversion.
