### PR TITLE
Corrected size of allocated memory for field name in NcCompoundType::get...

### DIFF
--- a/cxx4/ncCompoundType.cpp
+++ b/cxx4/ncCompoundType.cpp
@@ -131,7 +131,7 @@ NcType NcCompoundType::getMember(int memberIndex) const
 // Returns name of member field.
 std::string NcCompoundType::getMemberName(int memberIndex) const
 {
-  char fieldName[NC_MAX_NAME];
+  char fieldName[NC_MAX_NAME+1];
   ncCheck(nc_inq_compound_fieldname(groupId,myId,memberIndex, fieldName),__FILE__,__LINE__);
   return std::string(fieldName);
 }


### PR DESCRIPTION
Correcting error in #19, according to netcf-c documentation `NC_MAX_NAME` does not include terminating `\0`