### PR TITLE
Some small improvements to ncxx4-config

### DIFF
--- a/ncxx4-config.cmake.in
+++ b/ncxx4-config.cmake.in
@@ -13,7 +13,7 @@ cxx="@CMAKE_CXX_COMPILER@"
 
 cflags="-I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@"
 
-libs="-L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ @NC_LIBS@"
+libs="-L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lnetcdf-cxx4 -lnetcdf"
 
 has_dap="@USE_DAP@"
 if [ -z $has_dap ]; then

--- a/ncxx4-config.cmake.in
+++ b/ncxx4-config.cmake.in
@@ -15,27 +15,6 @@ cflags="-I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@"
 
 libs="-L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lnetcdf-cxx4 -lnetcdf"
 
-has_dap="@USE_DAP@"
-if [ -z $has_dap ]; then
-        has_dap="no"
-else
-has_dap="yes"
-fi
-
-has_nc2="@BUILD_V2@"
-if [ -z $has_nc2 ] || [ "$has_nc2" = "OFF" ]; then
-        has_nc2="no"
-else
-has_nc2="yes"
-fi
-
-has_nc4="@USE_NETCDF4@"
-if [ -z $has_nc4 ]; then
-        has_nc4="no"
-else
-has_nc4="yes"
-fi
-
 version="@PACKAGE@ @VERSION@"
 
 usage()
@@ -50,9 +29,6 @@ Available values for OPTION include:
   --cc          C compiler
   --cxx         C++ compiler
   --cflags      pre-processor and compiler flags
-  --has-dap     whether OPeNDAP is enabled in this build
-  --has-nc2     whether NetCDF-2 API is enabled
-  --has-nc4     whether NetCDF-4/HDF-5 is enabled in this build
   --libs        library linking information for netcdf
   --prefix      Install prefix
   --includedir  Include directory
@@ -75,10 +51,6 @@ all()
         echo
         echo "  --cxx       -> $cxx"
         echo
-        echo "  --has-dap   -> $has_dap"
-        echo "  --has-nc2   -> $has_nc2"
-        echo "  --has-nc4   -> $has_nc4"
-	    echo
         echo "  --prefix    -> $prefix"
         echo "  --includedir-> $includedir"
         echo "  --libdir    -> $libdir"
@@ -123,18 +95,6 @@ while test $# -gt 0; do
 
      --libs)
        	echo $libs
-       	;;
-
-    --has-dap)
-       	echo $has_dap
-       	;;
-
-    --has-nc2)
-       	echo $has_nc2
-       	;;
-
-    --has-nc4)
-       	echo $has_nc4
        	;;
 
     --prefix)

--- a/ncxx4-config.cmake.in
+++ b/ncxx4-config.cmake.in
@@ -56,6 +56,7 @@ Available values for OPTION include:
   --libs        library linking information for netcdf
   --prefix      Install prefix
   --includedir  Include directory
+  --libdir      Library directory
   --version     Library version
 
 EOF
@@ -77,9 +78,10 @@ all()
         echo "  --has-dap   -> $has_dap"
         echo "  --has-nc2   -> $has_nc2"
         echo "  --has-nc4   -> $has_nc4"
-	echo
+	    echo
         echo "  --prefix    -> $prefix"
         echo "  --includedir-> $includedir"
+        echo "  --libdir    -> $libdir"
         echo "  --version   -> $version"
         echo
 }
@@ -142,6 +144,10 @@ while test $# -gt 0; do
     --includedir)
        	echo "${includedir}"
        	;;
+
+    --libdir)
+        echo "${libdir}"
+        ;;
 
     --version)
 	echo $version

--- a/ncxx4-config.cmake.in
+++ b/ncxx4-config.cmake.in
@@ -74,50 +74,50 @@ while test $# -gt 0; do
     case "$1" in
 
     --help)
-	usage 0
-	;;
+    usage 0
+    ;;
 
     --all)
-	all
-	;;
+    all
+    ;;
 
     --cc)
-	echo $cc
-	;;
+    echo $cc
+    ;;
 
     --cxx)
-	echo $cxx
-	;;
+    echo $cxx
+    ;;
 
     --cflags)
-	echo $cflags
-	;;
+    echo $cflags
+    ;;
 
      --libs)
-       	echo $libs
-       	;;
+        echo $libs
+        ;;
 
     --prefix)
-       	echo "${prefix}"
-       	;;
+        echo "${prefix}"
+        ;;
 
     --includedir)
-       	echo "${includedir}"
-       	;;
+        echo "${includedir}"
+        ;;
 
     --libdir)
         echo "${libdir}"
         ;;
 
     --version)
-	echo $version
-	;;
+    echo $version
+    ;;
 
     *)
         echo "unknown option: $1"
-	usage
-	exit 1
-	;;
+    usage
+    exit 1
+    ;;
     esac
     shift
 done

--- a/ncxx4-config.in
+++ b/ncxx4-config.in
@@ -10,21 +10,8 @@ includedir=@includedir@
 
 cc="@CC@"
 cxx="@CXX@"
-fc="@FC@"
 cflags=" -I${includedir} @CPPFLAGS@" 
-fflags="@FFLAGS@ @MOD_FLAG@${includedir}"
 libs="-L${libdir} @NC_LIBS@ -lnetcdf"
-flibs="-L${libdir} @NC_FLIBS@"
-has_dap="@HAS_DAP@"
-has_nc2="@HAS_NC2@"
-has_nc4="@HAS_NC4@"
-has_hdf4="@HAS_HDF4@"
-has_pnetcdf="@HAS_PNETCDF@"
-has_hdf5="@HAS_HDF5@"
-has_f77="@HAS_F77@"
-has_f90="@HAS_F90@"
-has_cxx="@HAS_CXX@"
-has_szlib="@HAS_SZLIB@"
 version="@PACKAGE_NAME@ @PACKAGE_VERSION@"
 
 usage()
@@ -39,9 +26,6 @@ Available values for OPTION include:
   --cc          C compiler
   --cxx         C++ compiler
   --cflags      pre-processor and compiler flags
-  --has-dap     whether OPeNDAP is enabled in this build
-  --has-nc2     whether NetCDF-2 API is enabled
-  --has-nc4     whether NetCDF-4/HDF-5 is enabled in this build
   --libs        library linking information for netcdf
   --prefix      Install prefix
   --includedir  Include directory
@@ -64,10 +48,6 @@ all()
         echo
         echo "  --cxx       -> $cxx"
         echo
-        echo "  --has-dap   -> $has_dap"
-        echo "  --has-nc2   -> $has_nc2"
-        echo "  --has-nc4   -> $has_nc4"
-	echo
         echo "  --prefix    -> $prefix"
         echo "  --includedir-> $includedir"
         echo "  --libdir    -> $libdir"
@@ -112,18 +92,6 @@ while test $# -gt 0; do
 
      --libs)
        	echo $libs
-       	;;
-
-    --has-dap)
-       	echo $has_dap
-       	;;
-
-    --has-nc2)
-       	echo $has_nc2
-       	;;
-
-    --has-nc4)
-       	echo $has_nc4
        	;;
 
     --prefix)

--- a/ncxx4-config.in
+++ b/ncxx4-config.in
@@ -10,7 +10,7 @@ includedir=@includedir@
 
 cc="@CC@"
 cxx="@CXX@"
-cflags=" -I${includedir} @CPPFLAGS@" 
+cflags="-I${includedir} @CPPFLAGS@"
 libs="-L${libdir} @NC_LIBS@ -lnetcdf"
 version="@PACKAGE_NAME@ @PACKAGE_VERSION@"
 
@@ -71,50 +71,50 @@ while test $# -gt 0; do
     case "$1" in
 
     --help)
-	usage 0
-	;;
+    usage 0
+    ;;
 
     --all)
-	all
-	;;
+    all
+    ;;
 
     --cc)
-	echo $cc
-	;;
+    echo $cc
+    ;;
 
     --cxx)
-	echo $cxx
-	;;
+    echo $cxx
+    ;;
 
     --cflags)
-	echo $cflags
-	;;
+    echo $cflags
+    ;;
 
      --libs)
-       	echo $libs
-       	;;
+        echo $libs
+        ;;
 
     --prefix)
-       	echo "${prefix}"
-       	;;
+        echo "${prefix}"
+        ;;
 
     --includedir)
-       	echo "${includedir}"
-       	;;
+        echo "${includedir}"
+        ;;
 
     --libdir)
         echo "${libdir}"
         ;;
 
     --version)
-	echo $version
-	;;
+    echo $version
+    ;;
 
     *)
         echo "unknown option: $1"
-	usage
-	exit 1
-	;;
+    usage
+    exit 1
+    ;;
     esac
     shift
 done

--- a/ncxx4-config.in
+++ b/ncxx4-config.in
@@ -45,6 +45,7 @@ Available values for OPTION include:
   --libs        library linking information for netcdf
   --prefix      Install prefix
   --includedir  Include directory
+  --libdir      Library directory
   --version     Library version
 
 EOF
@@ -69,6 +70,7 @@ all()
 	echo
         echo "  --prefix    -> $prefix"
         echo "  --includedir-> $includedir"
+        echo "  --libdir    -> $libdir"
         echo "  --version   -> $version"
         echo
 }
@@ -131,6 +133,10 @@ while test $# -gt 0; do
     --includedir)
        	echo "${includedir}"
        	;;
+
+    --libdir)
+        echo "${libdir}"
+        ;;
 
     --version)
 	echo $version


### PR DESCRIPTION
- Adds `--libdir` option, to mirror `nc-config`
- Fix CMake version not printing the libraries with `--libs`
- Remove some old options

I think there might still be an issue with `--libs` not being complete. Neither the Autotools nor CMake versions includes the path to the C library.