### PR TITLE
[CMake] Remove debug info from release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,15 +426,12 @@ ENDIF()
 ##
 
 IF(CMAKE_COMPILER_IS_GNUCC OR APPLE)
-  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wno-unused-variable -Wno-unused-parameter")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wno-unused-variable -Wno-unused-parameter")
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused-variable -Wno-unused-parameter")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable -Wno-unused-parameter")
 
   OPTION(ENABLE_COVERAGE_TESTS "Enable compiler flags needed to perform coverage tests." OFF)
   OPTION(ENABLE_CONVERSION_WARNINGS "Enable warnings for implicit conversion from 64 to 32-bit datatypes." ON)
   OPTION(ENABLE_LARGE_FILE_TESTS "Enable large file tests." OFF)
-
-  # Debugging flags
-  SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall")
 
   # Check to see if -Wl,--no-undefined is supported.
   CHECK_CXX_LINKER_FLAG("-Wl,--no-undefined" LIBTOOL_HAS_NO_UNDEFINED)


### PR DESCRIPTION
Removed debug flag (`-g`) which was always defined (also in `Release` config).

The flag gets automatically added in `Debug` config.