### PR TITLE
Fix cmake build on macOS with hdf5 1.13.0 and cmake 3.17.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ ELSE(MSVC)
   FIND_PACKAGE(HDF5 COMPONENTS C HL REQUIRED)
 ENDIF(MSVC)
 
-CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5free_memory "" HAVE_H5FREE_MEMORY)
+CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARIES} H5free_memory "" HAVE_H5FREE_MEMORY)
 IF(NOT HAVE_H5FREE_MEMORY)
   MESSAGE(STATUS "Plugin support requires libhdf5 with H5Free support. Your libhdf5 install does not provide H5Free.  Please install a newer version of libhdf5 if you require plugin compression support.")
   SET(NC_HAS_DEF_VAR_FILTER "")

--- a/cxx4/CMakeLists.txt
+++ b/cxx4/CMakeLists.txt
@@ -35,7 +35,7 @@ TARGET_INCLUDE_DIRECTORIES(netcdf-cxx4 PUBLIC
   )
 TARGET_LINK_LIBRARIES(netcdf-cxx4 PUBLIC netCDF::netcdf)
 TARGET_LINK_LIBRARIES(netcdf-cxx4 PUBLIC ${ALL_TLL_LIBS})
-target_include_directories(netcdf-cxx4 SYSTEM PUBLIC "${HDF5_C_INCLUDE_DIRS}")
+target_include_directories(netcdf-cxx4 SYSTEM PUBLIC "${HDF5_INCLUDE_DIRS}")
 
 SET_TARGET_PROPERTIES(netcdf-cxx4 PROPERTIES
   VERSION ${NCXX_LIB_VERSION}


### PR DESCRIPTION
Resolved 2 Issue preventing CMake netcdf-cxx4 build on MacOS.

Trying to build latest HDF5, NetCDF-c, and then NetCDF-cxx4 from source on macOS Mojave using cmake version 3.17.2, hdf5 1.13.0 at 88a39adaa, and netcdf-c 4.8.0 at c2ea69df. 

With NetCDF-cxx4, first issue:

```
mkdir build && cd build
cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_DIR=/usr/local/HDF_Group/HDF5/1.13.0/share/cmake/hdf5/ ..
```


```
[...]
-- Found HDF5: hdf5-shared (found version "1.13.0") found components: C HL                                                                                           
CMake Error at CMakeLists.txt:415 (CHECK_LIBRARY_EXISTS):                         
  CHECK_LIBRARY_EXISTS Macro invoked with incorrect arguments for macro
  named: CHECK_LIBRARY_EXISTS                                                     
                                                                                  
                                                                                                                                                                     
-- Plugin support requires libhdf5 with H5Free support. Your libhdf5 install does not provide H5Free.  Please install a newer version of libhdf5 if you require plugin compression support.
[...]
-- Configuring incomplete, errors occurred!  
```

Attributed to blank variable `HDF5_C_LIBRARY_hdf5` in CMakeLists.txt. The `FIND_PACKAGE(HDF5...` call [1] sets `HDF5_C_LIBRARIES`. Looks like this snippet might have been copied from the NetCDF-c cmake, but the part that actually sets `HDF5_C_LIBRARY_hdf5` from `HDF5_C_LIBRARIES` was omitted? Solution, modify `HDF5_C_LIBRARY_hdf5` -> `HDF5_C_LIBRARIES`. 


Build gets a little further, but gets stuck with error:


```
[...]
CMake Error in cxx4/CMakeLists.txt:
  Target "netcdf-cxx4" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/full/path/to/netcdf-cxx4/cxx4/"

  which is prefixed in the source directory.

-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

Using [2] [3]:

```
include(CMakePrintHelpers) # debug
cmake_print_properties(TARGETS netcdf-cxx4 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES) # debug
variable_watch(HDF5_C_INCLUDE_DIRS) # debug
target_include_directories(netcdf-cxx4 SYSTEM PUBLIC "${HDF5_C_INCLUDE_DIRS}")
cmake_print_properties(TARGETS netcdf-cxx4 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES) # debug
```

Finally tracked this down to the line above in cxx4/CMakeLists.txt referring to empty variable `HDF5_C_INCLUDE_DIRS`. Again FindHDF5 [1] sets `HDF5_INCLUDE_DIRS`, so changing `HDF5_C_INCLUDE_DIRS` -> `HDF5_INCLUDE_DIRS` seems to fix. Interestingly, compilation and tests pass even removing that line. Is that line necessary?

Thanks!


[1] https://cmake.org/cmake/help/v3.0/module/FindHDF5.html
[2] https://cmake.org/cmake/help/latest/module/CMakePrintHelpers.html
[3] https://cmake.org/cmake/help/latest/command/variable_watch.html