### PR TITLE
Fix the build with -no-undefined.

### DIFF
--- a/cxx4/Makefile.am
+++ b/cxx4/Makefile.am
@@ -3,15 +3,13 @@
 
 # This file builds the new C++-4 interface.
 
-# Point pre-preprocessor to netcdf-4 directory (libsrc4).
-LDADD = $(top_builddir)/cxx4/libnetcdf_c++4.la  -lnetcdf
-
 # This is our output library.
 lib_LTLIBRARIES = libnetcdf_c++4.la
 
 # For rules updating the version info, see
 # http://www.gnu.org/s/libtool/manual/html_node/Updating-version-info.html
 libnetcdf_c__4_la_LDFLAGS = -version-info 2:0:1 -no-undefined
+libnetcdf_c__4_la_LIBADD = -lnetcdf
 
 # These headers will be installed in the users header directory.
 include_HEADERS = netcdf ncAtt.h ncCheck.h ncDim.h ncException.h	\

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -20,6 +20,7 @@ lib_LTLIBRARIES = libh5bzip2.la
 
 libh5bzip2_la_SOURCES = ${HDF5PLUGINSRC}
 libh5bzip2_la_LDFLAGS = -module -avoid-version -shared -export-dynamic -no-undefined
+libh5bzip2_la_LIBADD = -lhdf5
 
 libmisc_la_SOURCES = H5Zmisc.c H5Zutil.c h5misc.h
 libmisc_la_LDFLAGS = -module -avoid-version -shared -export-dynamic -no-undefined -rpath ${abs_builddir}


### PR DESCRIPTION
When building netcdf-cxx4 with sblitool (https://dev.midipix.org/cross/slibtool) it fails with many undefined references. This is because the build used `-no-undefined` which GNU libtool silently ignores while slibtool does not.

1. `-lnetcdf` should be in `LIBADD` and not `LDADD`. - Build log: [netcdf-cxx4.rdlibtool.log](https://github.com/Unidata/netcdf-cxx4/files/6207359/netcdf-cxx4.rdlibtool.log)
2. The global `LDADD` variable is unused and `LDADD` should be used for linking dependencies for programs, for example: `foo_LDADD = bar.la`. The global variable is `LIBS`, but it should just be removed instead since linking against yourself is wrong in this case.
3. `libh5bzip2.la` depends on hdf5 and the `-lhdf5` linker flag is missing.
```
rdlibtool --tag=CC --mode=link gcc -g -O2 -module -avoid-version -shared -export-dynamic -no-undefined -o libh5bzip2.la -rpath /usr/local/lib H5Zbzip2.lo blocksort.lo huffman.lo crctable.lo randtable.lo compress.lo decompress.lo bzlib.lo

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/netcdf-cxx4/plugins"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 324927}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 315376}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = 4.
rdlibtool: lconf: found "/tmp/netcdf-cxx4/libtool".
rdlibtool: link: ln -s /dev/null .libs/libh5bzip2.a.disabled
rdlibtool: link: gcc .libs/H5Zbzip2.o .libs/blocksort.o .libs/huffman.o .libs/crctable.o .libs/randtable.o .libs/compress.o .libs/decompress.o .libs/bzlib.o -g -O2 -shared -fPIC -Wl,--no-undefined -o .libs/libh5bzip2.so -Wl,--export-dynamic
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: .libs/H5Zbzip2.o: in function `H5Z_filter_bzip2':
/tmp/netcdf-cxx4/plugins/H5Zbzip2.c:204: undefined reference to `H5free_memory'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/netcdf-cxx4/plugins/H5Zbzip2.c:212: undefined reference to `H5free_memory'
collect2: error: ld returned 1 exit status
rdlibtool: exec error upon slbt_exec_link_create_library(), line 1446: (see child process error messages).
rdlibtool: < returned to > slbt_exec_link(), line 1868.
make[1]: *** [Makefile:467: libh5bzip2.la] Error 2
make[1]: Leaving directory '/tmp/netcdf-cxx4/plugins'
make: *** [Makefile:542: install-recursive] Error 1
```