### PR TITLE
Resolve bad delete #98

### DIFF
--- a/cxx4/ncGroup.cpp
+++ b/cxx4/ncGroup.cpp
@@ -104,7 +104,7 @@ string NcGroup::getName(bool fullName) const {
     char* charName= new char[lenp+1];
     ncCheck(nc_inq_grpname_full(myId,&lenp,charName),__FILE__,__LINE__);
     groupName = charName;
-    delete charName;
+    delete[] charName;
   }
   else {
     // return the (local) name of this group.


### PR DESCRIPTION
Use `delete[]` rather `delete` for deleting heap allocated char array.