### PR TITLE
Fix searching parent/children groups in `NcGroup::getCoordVar[s]`

### DIFF
--- a/cxx4/ncGroup.cpp
+++ b/cxx4/ncGroup.cpp
@@ -1346,6 +1346,9 @@ map<string,NcGroup> NcGroup::getCoordVars(NcGroup::Location location) const {
 
 // Get the NcDim and NcVar object pair for a named coordinate variables.
 void NcGroup::getCoordVar(const string& coordVarName, NcDim& ncDim, NcVar& ncVar, NcGroup::Location location) const {
+  // Nullify existing dim/var in case no coordinate variable found
+  ncDim = NcDim{};
+  ncVar = NcVar{};
 
   // search in current group and parent groups.
   multimap<string,NcDim>::iterator itD;
@@ -1385,14 +1388,4 @@ void NcGroup::getCoordVar(const string& coordVarName, NcDim& ncDim, NcVar& ncVar
       if(!ncDim.isNull()) break;
     }
   }
-
-  if(ncDim.isNull()) {
-    // return null objects as no coordinates variables were obtained.
-    NcDim dimTmp;
-    NcVar varTmp;
-    ncDim=dimTmp;
-    ncVar=varTmp;
-    return;
-  }
-
 }

--- a/cxx4/ncGroup.cpp
+++ b/cxx4/ncGroup.cpp
@@ -1304,24 +1304,29 @@ map<string,NcGroup> NcGroup::getCoordVars(NcGroup::Location location) const {
   NcGroup tmpGroup(*this);
   multimap<string,NcDim>::iterator itD;
   multimap<string,NcVar>::iterator itV;
+  bool check_current_group = !(location == Parents || location == Children);
   const bool check_parent_groups = (location == Parents || location == ParentsAndCurrent || location == All);
   const bool check_child_groups = (location == Children || location == ChildrenAndCurrent || location == All);
 
   while(1) {
     // get the collection of NcDim objects defined in this group.
-    multimap<string,NcDim> dimTmp(tmpGroup.getDims());
-    multimap<string,NcVar> varTmp(tmpGroup.getVars());
-    for (itD=dimTmp.begin();itD!=dimTmp.end();itD++) {
-      string coordName(itD->first);
-      itV = varTmp.find(coordName);
-      if(itV != varTmp.end()) {
-	coordVars.insert(pair<const string,NcGroup>(string(coordName),tmpGroup));
+    if (check_current_group) {
+      multimap<string,NcDim> dimTmp(tmpGroup.getDims());
+      multimap<string,NcVar> varTmp(tmpGroup.getVars());
+      for (itD=dimTmp.begin();itD!=dimTmp.end();itD++) {
+        string coordName(itD->first);
+        itV = varTmp.find(coordName);
+        if(itV != varTmp.end()) {
+          coordVars.insert(pair<const string,NcGroup>(string(coordName),tmpGroup));
+        }
       }
     }
 
     if (!check_parent_groups || tmpGroup.isRootGroup()) {
       break;
     }
+    check_current_group = true;
+
     // continue loop with the parent.
     tmpGroup=tmpGroup.getParentGroup();
   }
@@ -1346,23 +1351,27 @@ void NcGroup::getCoordVar(const string& coordVarName, NcDim& ncDim, NcVar& ncVar
   multimap<string,NcDim>::iterator itD;
   NcGroup tmpGroup(*this);
   multimap<string,NcVar>::iterator itV;
+  bool check_current_group = !(location == Parents || location == Children);
   const bool check_parent_groups = (location == Parents || location == ParentsAndCurrent || location == All);
   const bool check_child_groups = (location == Children || location == ChildrenAndCurrent || location == All);
 
   while(1) {
     // get the collection of NcDim objects defined in this group.
-    multimap<string,NcDim> dimTmp(tmpGroup.getDims());
-    multimap<string,NcVar> varTmp(tmpGroup.getVars());
-    itD=dimTmp.find(coordVarName);
-    itV=varTmp.find(coordVarName);
-    if(itD != dimTmp.end() && itV != varTmp.end()) {
-      ncDim=itD->second;
-      ncVar=itV->second;
-      return;
+    if (check_current_group) {
+      multimap<string,NcDim> dimTmp(tmpGroup.getDims());
+      multimap<string,NcVar> varTmp(tmpGroup.getVars());
+      itD=dimTmp.find(coordVarName);
+      itV=varTmp.find(coordVarName);
+      if(itD != dimTmp.end() && itV != varTmp.end()) {
+        ncDim=itD->second;
+        ncVar=itV->second;
+        return;
+      }
     }
     if(!check_parent_groups || tmpGroup.isRootGroup()) {
       break;
     }
+    check_current_group = true;
     // continue loop with the parent.
     tmpGroup=tmpGroup.getParentGroup();
   }

--- a/cxx4/ncGroup.cpp
+++ b/cxx4/ncGroup.cpp
@@ -1336,7 +1336,7 @@ map<string,NcGroup> NcGroup::getCoordVars(NcGroup::Location location) const {
 }
 
 // Get the NcDim and NcVar object pair for a named coordinate variables.
-void NcGroup::getCoordVar(string& coordVarName, NcDim& ncDim, NcVar& ncVar, NcGroup::Location location) const {
+void NcGroup::getCoordVar(const string& coordVarName, NcDim& ncDim, NcVar& ncVar, NcGroup::Location location) const {
 
   // search in current group and parent groups.
   multimap<string,NcDim>::iterator itD;

--- a/cxx4/ncGroup.cpp
+++ b/cxx4/ncGroup.cpp
@@ -1327,7 +1327,7 @@ map<string,NcGroup> NcGroup::getCoordVars(NcGroup::Location location) const {
     multimap<string,NcGroup>::iterator it;
     multimap<string,NcGroup> groups(getGroups());
     for (it=groups.begin();it!=groups.end();it++) {
-      map<string,NcGroup> coordVarsTmp=getCoordVars(ChildrenAndCurrent);
+      map<string,NcGroup> coordVarsTmp = it->second.getCoordVars(ChildrenAndCurrent);
       coordVars.insert(coordVarsTmp.begin(),coordVarsTmp.end());
     }
   }
@@ -1365,7 +1365,7 @@ void NcGroup::getCoordVar(const string& coordVarName, NcDim& ncDim, NcVar& ncVar
     multimap<string,NcGroup>::iterator it;
     multimap<string,NcGroup> groups(getGroups());
     for (it=groups.begin();it!=groups.end();it++) {
-      getCoordVar(coordVarName,ncDim,ncVar,ChildrenAndCurrent);
+      it->second.getCoordVar(coordVarName,ncDim,ncVar,ChildrenAndCurrent);
       if(!ncDim.isNull()) break;
     }
   }

--- a/cxx4/ncGroup.cpp
+++ b/cxx4/ncGroup.cpp
@@ -1304,6 +1304,9 @@ map<string,NcGroup> NcGroup::getCoordVars(NcGroup::Location location) const {
   NcGroup tmpGroup(*this);
   multimap<string,NcDim>::iterator itD;
   multimap<string,NcVar>::iterator itV;
+  const bool check_parent_groups = (location == Parents || location == ParentsAndCurrent || location == All);
+  const bool check_child_groups = (location == Children || location == ChildrenAndCurrent || location == All);
+
   while(1) {
     // get the collection of NcDim objects defined in this group.
     multimap<string,NcDim> dimTmp(tmpGroup.getDims());
@@ -1315,7 +1318,8 @@ map<string,NcGroup> NcGroup::getCoordVars(NcGroup::Location location) const {
 	coordVars.insert(pair<const string,NcGroup>(string(coordName),tmpGroup));
       }
     }
-    if(location != ParentsAndCurrent || location != All || tmpGroup.isRootGroup()) {
+
+    if (!check_parent_groups || tmpGroup.isRootGroup()) {
       break;
     }
     // continue loop with the parent.
@@ -1323,7 +1327,7 @@ map<string,NcGroup> NcGroup::getCoordVars(NcGroup::Location location) const {
   }
 
   // search in child groups (makes recursive calls).
-  if(location == ChildrenAndCurrent || location == All ) {
+  if (check_child_groups) {
     multimap<string,NcGroup>::iterator it;
     multimap<string,NcGroup> groups(getGroups());
     for (it=groups.begin();it!=groups.end();it++) {
@@ -1342,6 +1346,9 @@ void NcGroup::getCoordVar(const string& coordVarName, NcDim& ncDim, NcVar& ncVar
   multimap<string,NcDim>::iterator itD;
   NcGroup tmpGroup(*this);
   multimap<string,NcVar>::iterator itV;
+  const bool check_parent_groups = (location == Parents || location == ParentsAndCurrent || location == All);
+  const bool check_child_groups = (location == Children || location == ChildrenAndCurrent || location == All);
+
   while(1) {
     // get the collection of NcDim objects defined in this group.
     multimap<string,NcDim> dimTmp(tmpGroup.getDims());
@@ -1353,7 +1360,7 @@ void NcGroup::getCoordVar(const string& coordVarName, NcDim& ncDim, NcVar& ncVar
       ncVar=itV->second;
       return;
     }
-    if(location != ParentsAndCurrent || location != All || tmpGroup.isRootGroup()) {
+    if(!check_parent_groups || tmpGroup.isRootGroup()) {
       break;
     }
     // continue loop with the parent.
@@ -1361,7 +1368,7 @@ void NcGroup::getCoordVar(const string& coordVarName, NcDim& ncDim, NcVar& ncVar
   }
 
   // search in child groups (makes recursive calls).
-  if(location == ChildrenAndCurrent || location == All ) {
+  if (check_child_groups) {
     multimap<string,NcGroup>::iterator it;
     multimap<string,NcGroup> groups(getGroups());
     for (it=groups.begin();it!=groups.end();it++) {

--- a/cxx4/ncGroup.h
+++ b/cxx4/ncGroup.h
@@ -559,7 +559,7 @@ namespace netCDF
       \param location Enumeration type controlling the groups to search.
       \return         The set of names of dimension variables.
     */
-    void getCoordVar(std::string& coordVarName, NcDim& ncDim, NcVar& ncVar, NcGroup::Location location=Current) const;
+    void getCoordVar(const std::string& coordVarName, NcDim& ncDim, NcVar& ncVar, NcGroup::Location location=Current) const;
 
 
   protected:

--- a/cxx4/test_dim.cpp
+++ b/cxx4/test_dim.cpp
@@ -37,6 +37,12 @@ int main()
       NcDim dim7 = groupB.addDim("dim7",17);
       cout <<"    -----------   passed\n";
 
+      cout <<left<<setw(55)<<"Testing addVar(\"dimensionName\")";
+      // Coordinate variables
+      NcVar var1 = ncFile.addVar("dim1", NcInt{});
+      NcVar var4 = groupB.addVar("dim4", NcInt{});
+      cout <<"    -----------   passed\n";
+
       cout <<left<<setw(55)<<"Testing NcDim::isUnlimited()";
       if( dim1.isUnlimited())    throw NcException("Error in test 1.1",__FILE__,__LINE__);
       if( !dim2.isUnlimited())   throw NcException("Error in test 1.2",__FILE__,__LINE__);
@@ -322,12 +328,140 @@ int main()
 
       cout <<"    -----------   passed\n";
 
+      cout <<left<<setw(55)<<"Testing NcGroup::getCoordVars([netCDF::Location])";
+      {
+        if (ncFile.getCoordVars(NcGroup::Current).count("dim1") != 1) throw NcException("Error in test 10.1", __FILE__, __LINE__);
+        if (ncFile.getCoordVars(NcGroup::Current).count("dim4") != 0) throw NcException("Error in test 10.2", __FILE__, __LINE__);
+        if (ncFile.getCoordVars(NcGroup::Children).count("dim1") != 0) throw NcException("Error in test 10.3", __FILE__, __LINE__);
+        if (ncFile.getCoordVars(NcGroup::Children).count("dim4") != 1) throw NcException("Error in test 10.4", __FILE__, __LINE__);
+        if (ncFile.getCoordVars(NcGroup::ChildrenAndCurrent).count("dim1") != 1) throw NcException("Error in test 10.5", __FILE__, __LINE__);
+        if (ncFile.getCoordVars(NcGroup::ChildrenAndCurrent).count("dim4") != 1) throw NcException("Error in test 10.6", __FILE__, __LINE__);
+        if (ncFile.getCoordVars(NcGroup::Parents).count("dim1") != 0) throw NcException("Error in test 10.7", __FILE__, __LINE__);
+        if (ncFile.getCoordVars(NcGroup::Parents).count("dim4") != 0) throw NcException("Error in test 10.8", __FILE__, __LINE__);
+        if (ncFile.getCoordVars(NcGroup::ParentsAndCurrent).count("dim1") != 1) throw NcException("Error in test 10.9", __FILE__, __LINE__);
+        if (ncFile.getCoordVars(NcGroup::ParentsAndCurrent).count("dim4") != 0) throw NcException("Error in test 10.10", __FILE__, __LINE__);
+        if (ncFile.getCoordVars(NcGroup::All).count("dim1") != 1) throw NcException("Error in test 10.11", __FILE__, __LINE__);
+        if (ncFile.getCoordVars(NcGroup::All).count("dim4") != 1) throw NcException("Error in test 10.12", __FILE__, __LINE__);
+
+        if (groupA.getCoordVars(NcGroup::Current).count("dim1") != 0) throw NcException("Error in test 10.13", __FILE__, __LINE__);
+        if (groupA.getCoordVars(NcGroup::Current).count("dim4") != 0) throw NcException("Error in test 10.14", __FILE__, __LINE__);
+        if (groupA.getCoordVars(NcGroup::Children).count("dim1") != 0) throw NcException("Error in test 10.15", __FILE__, __LINE__);
+        if (groupA.getCoordVars(NcGroup::Children).count("dim4") != 1) throw NcException("Error in test 10.16", __FILE__, __LINE__);
+        if (groupA.getCoordVars(NcGroup::ChildrenAndCurrent).count("dim1") != 0) throw NcException("Error in test 10.17", __FILE__, __LINE__);
+        if (groupA.getCoordVars(NcGroup::ChildrenAndCurrent).count("dim4") != 1) throw NcException("Error in test 10.18", __FILE__, __LINE__);
+        if (groupA.getCoordVars(NcGroup::Parents).count("dim1") != 1) throw NcException("Error in test 10.19", __FILE__, __LINE__);
+        if (groupA.getCoordVars(NcGroup::Parents).count("dim4") != 0) throw NcException("Error in test 10.20", __FILE__, __LINE__);
+        if (groupA.getCoordVars(NcGroup::ParentsAndCurrent).count("dim1") != 1) throw NcException("Error in test 10.21", __FILE__, __LINE__);
+        if (groupA.getCoordVars(NcGroup::ParentsAndCurrent).count("dim4") != 0) throw NcException("Error in test 10.22", __FILE__, __LINE__);
+        if (groupA.getCoordVars(NcGroup::All).count("dim1") != 1) throw NcException("Error in test 10.23", __FILE__, __LINE__);
+        if (groupA.getCoordVars(NcGroup::All).count("dim4") != 1) throw NcException("Error in test 10.24", __FILE__, __LINE__);
+
+        if (groupB.getCoordVars(NcGroup::Current).count("dim1") != 0) throw NcException("Error in test 10.25", __FILE__, __LINE__);
+        if (groupB.getCoordVars(NcGroup::Current).count("dim4") != 1) throw NcException("Error in test 10.26", __FILE__, __LINE__);
+        if (groupB.getCoordVars(NcGroup::Children).count("dim1") != 0) throw NcException("Error in test 10.27", __FILE__, __LINE__);
+        if (groupB.getCoordVars(NcGroup::Children).count("dim4") != 0) throw NcException("Error in test 10.28", __FILE__, __LINE__);
+        if (groupB.getCoordVars(NcGroup::ChildrenAndCurrent).count("dim1") != 0) throw NcException("Error in test 10.29", __FILE__, __LINE__);
+        if (groupB.getCoordVars(NcGroup::ChildrenAndCurrent).count("dim4") != 1) throw NcException("Error in test 10.30", __FILE__, __LINE__);
+        if (groupB.getCoordVars(NcGroup::Parents).count("dim1") != 1) throw NcException("Error in test 10.31", __FILE__, __LINE__);
+        if (groupB.getCoordVars(NcGroup::Parents).count("dim4") != 0) throw NcException("Error in test 10.32", __FILE__, __LINE__);
+        if (groupB.getCoordVars(NcGroup::ParentsAndCurrent).count("dim1") != 1) throw NcException("Error in test 10.33", __FILE__, __LINE__);
+        if (groupB.getCoordVars(NcGroup::ParentsAndCurrent).count("dim4") != 1) throw NcException("Error in test 10.34", __FILE__, __LINE__);
+        if (groupB.getCoordVars(NcGroup::All).count("dim1") != 1) throw NcException("Error in test 10.35", __FILE__, __LINE__);
+        if (groupB.getCoordVars(NcGroup::All).count("dim4") != 1) throw NcException("Error in test 10.36", __FILE__, __LINE__);
+      }
+
+      cout <<"    -----------   passed\n";
+
+      cout <<left<<setw(55)<<"Testing NcGroup::getCoordVars([netCDF::Location])";
+      {
+        NcDim dim;
+        NcVar var;
+        
+        ncFile.getCoordVar("dim1", dim, var, NcGroup::Current);
+        if (dim.getName() != "dim1" || var.getName() != "dim1") throw NcException("Error in test 11.1", __FILE__, __LINE__);
+        ncFile.getCoordVar("dim1", dim, var, NcGroup::Parents);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.2", __FILE__, __LINE__);
+        ncFile.getCoordVar("dim1", dim, var, NcGroup::ParentsAndCurrent);
+        if (dim.getName() != "dim1" || var.getName() != "dim1") throw NcException("Error in test 11.3", __FILE__, __LINE__);
+        ncFile.getCoordVar("dim1", dim, var, NcGroup::Children);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.4", __FILE__, __LINE__);
+        ncFile.getCoordVar("dim1", dim, var, NcGroup::ChildrenAndCurrent);
+        if (dim.getName() != "dim1" || var.getName() != "dim1") throw NcException("Error in test 11.5", __FILE__, __LINE__);
+        ncFile.getCoordVar("dim1", dim, var, NcGroup::All);
+        if (dim.getName() != "dim1" || var.getName() != "dim1") throw NcException("Error in test 11.6", __FILE__, __LINE__);
+
+        ncFile.getCoordVar("dim4", dim, var, NcGroup::Current);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.7", __FILE__, __LINE__);
+        ncFile.getCoordVar("dim4", dim, var, NcGroup::Parents);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.8", __FILE__, __LINE__);
+        ncFile.getCoordVar("dim4", dim, var, NcGroup::ParentsAndCurrent);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.9", __FILE__, __LINE__);
+        ncFile.getCoordVar("dim4", dim, var, NcGroup::Children);
+        if (dim.getName() != "dim4" || var.getName() != "dim4") throw NcException("Error in test 11.10", __FILE__, __LINE__);
+        ncFile.getCoordVar("dim4", dim, var, NcGroup::ChildrenAndCurrent);
+        if (dim.getName() != "dim4" || var.getName() != "dim4") throw NcException("Error in test 11.11", __FILE__, __LINE__);
+        ncFile.getCoordVar("dim4", dim, var, NcGroup::All);
+        if (dim.getName() != "dim4" || var.getName() != "dim4") throw NcException("Error in test 11.12", __FILE__, __LINE__);
+
+        groupA.getCoordVar("dim1", dim, var, NcGroup::Current);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.13", __FILE__, __LINE__);
+        groupA.getCoordVar("dim1", dim, var, NcGroup::Parents);
+        if (dim.getName() != "dim1" || var.getName() != "dim1") throw NcException("Error in test 11.14", __FILE__, __LINE__);
+        groupA.getCoordVar("dim1", dim, var, NcGroup::ParentsAndCurrent);
+        if (dim.getName() != "dim1" || var.getName() != "dim1") throw NcException("Error in test 11.15", __FILE__, __LINE__);
+        groupA.getCoordVar("dim1", dim, var, NcGroup::Children);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.16", __FILE__, __LINE__);
+        groupA.getCoordVar("dim1", dim, var, NcGroup::ChildrenAndCurrent);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.17", __FILE__, __LINE__);
+        groupA.getCoordVar("dim1", dim, var, NcGroup::All);
+        if (dim.getName() != "dim1" || var.getName() != "dim1") throw NcException("Error in test 11.18", __FILE__, __LINE__);
+
+        groupA.getCoordVar("dim4", dim, var, NcGroup::Current);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.19", __FILE__, __LINE__);
+        groupA.getCoordVar("dim4", dim, var, NcGroup::Parents);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.20", __FILE__, __LINE__);
+        groupA.getCoordVar("dim4", dim, var, NcGroup::ParentsAndCurrent);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.21", __FILE__, __LINE__);
+        groupA.getCoordVar("dim4", dim, var, NcGroup::Children);
+        if (dim.getName() != "dim4" || var.getName() != "dim4") throw NcException("Error in test 11.22", __FILE__, __LINE__);
+        groupA.getCoordVar("dim4", dim, var, NcGroup::ChildrenAndCurrent);
+        if (dim.getName() != "dim4" || var.getName() != "dim4") throw NcException("Error in test 11.23", __FILE__, __LINE__);
+        groupA.getCoordVar("dim4", dim, var, NcGroup::All);
+        if (dim.getName() != "dim4" || var.getName() != "dim4") throw NcException("Error in test 11.24", __FILE__, __LINE__);
+
+        groupB.getCoordVar("dim1", dim, var, NcGroup::Current);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.25", __FILE__, __LINE__);
+        groupB.getCoordVar("dim1", dim, var, NcGroup::Parents);
+        if (dim.getName() != "dim1" || var.getName() != "dim1") throw NcException("Error in test 11.26", __FILE__, __LINE__);
+        groupB.getCoordVar("dim1", dim, var, NcGroup::ParentsAndCurrent);
+        if (dim.getName() != "dim1" || var.getName() != "dim1") throw NcException("Error in test 11.27", __FILE__, __LINE__);
+        groupB.getCoordVar("dim1", dim, var, NcGroup::Children);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.28", __FILE__, __LINE__);
+        groupB.getCoordVar("dim1", dim, var, NcGroup::ChildrenAndCurrent);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.29", __FILE__, __LINE__);
+        groupB.getCoordVar("dim1", dim, var, NcGroup::All);
+        if (dim.getName() != "dim1" || var.getName() != "dim1") throw NcException("Error in test 11.30", __FILE__, __LINE__);
+
+        groupB.getCoordVar("dim4", dim, var, NcGroup::Current);
+        if (dim.getName() != "dim4" || var.getName() != "dim4") throw NcException("Error in test 11.31", __FILE__, __LINE__);
+        groupB.getCoordVar("dim4", dim, var, NcGroup::Parents);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.32", __FILE__, __LINE__);
+        groupB.getCoordVar("dim4", dim, var, NcGroup::ParentsAndCurrent);
+        if (dim.getName() != "dim4" || var.getName() != "dim4") throw NcException("Error in test 11.33", __FILE__, __LINE__);
+        groupB.getCoordVar("dim4", dim, var, NcGroup::Children);
+        if (!dim.isNull() || !var.isNull()) throw NcException("Error in test 11.34", __FILE__, __LINE__);
+        groupB.getCoordVar("dim4", dim, var, NcGroup::ChildrenAndCurrent);
+        if (dim.getName() != "dim4" || var.getName() != "dim4") throw NcException("Error in test 11.35", __FILE__, __LINE__);
+        groupB.getCoordVar("dim4", dim, var, NcGroup::All);
+        if (dim.getName() != "dim4" || var.getName() != "dim4") throw NcException("Error in test 11.36", __FILE__, __LINE__);
+      }
+      cout <<"    -----------   passed\n";
 
     }
   catch (NcException& e)
     {
       cout <<"\n";
-      e.what();
-      return e.errorCode();
+      cout << e.what() << std::endl;
+      return 1;
     }
 }

--- a/cxx4/test_dim.cpp
+++ b/cxx4/test_dim.cpp
@@ -287,43 +287,43 @@ int main()
 
       cout <<left<<setw(55)<<"Testing NcGroup::getDim(\"name\",[netCDF::Location])";
       {
-	if( ncFile.getDim("dim1",NcGroup::All).getName() !="dim1") throw NcException("Error in test 9.1",__FILE__,__LINE__);
-	if( ncFile.getDim("dim2",NcGroup::All).getName() !="dim2") throw NcException("Error in test 9.2",__FILE__,__LINE__);
-	if( ncFile.getDim("dim3",NcGroup::All).getName() !="dim3") throw NcException("Error in test 9.3",__FILE__,__LINE__);
-	if( ncFile.getDim("dim4",NcGroup::All).getName() !="dim4") throw NcException("Error in test 9.4",__FILE__,__LINE__);
-	if( ncFile.getDim("dim5",NcGroup::All).getName() !="dim5") throw NcException("Error in test 9.5",__FILE__,__LINE__);
-	if( ncFile.getDim("dim6",NcGroup::All).getName() !="dim6") throw NcException("Error in test 9.6",__FILE__,__LINE__);
-	if( ncFile.getDim("dim7",NcGroup::All).getName() !="dim7") throw NcException("Error in test 9.7",__FILE__,__LINE__);
-	if( groupB.getDim("dim1",NcGroup::All).getName() !="dim1") throw NcException("Error in test 9.8",__FILE__,__LINE__);
-	if( groupB.getDim("dim2",NcGroup::All).getName() !="dim2") throw NcException("Error in test 9.9",__FILE__,__LINE__);
-	if( groupB.getDim("dim3",NcGroup::All).getName() !="dim3") throw NcException("Error in test 9.10",__FILE__,__LINE__);
-	if( groupB.getDim("dim4",NcGroup::All).getName() !="dim4") throw NcException("Error in test 9.11",__FILE__,__LINE__);
-	if( groupB.getDim("dim5",NcGroup::All).getName() !="dim5") throw NcException("Error in test 9.12",__FILE__,__LINE__);
-	if( groupB.getDim("dim6",NcGroup::All).getName() !="dim6") throw NcException("Error in test 9.13",__FILE__,__LINE__);
-	if( groupB.getDim("dim7",NcGroup::All).getName() !="dim7") throw NcException("Error in test 9.14",__FILE__,__LINE__);
-	if( !ncFile.getDim("dim7").isNull())                            throw NcException("Error in test 9.15",__FILE__,__LINE__);
-	if( !ncFile.getDim("dim7",NcGroup::Current).isNull())           throw NcException("Error in test 9.16",__FILE__,__LINE__);
-	if( !ncFile.getDim("dim7",NcGroup::Parents).isNull())           throw NcException("Error in test 9.17",__FILE__,__LINE__);
-	if(  ncFile.getDim("dim7",NcGroup::Children).isNull())          throw NcException("Error in test 9.18",__FILE__,__LINE__);
-	if( !ncFile.getDim("dim7",NcGroup::ParentsAndCurrent).isNull()) throw NcException("Error in test 9.19",__FILE__,__LINE__);
-	if(  ncFile.getDim("dim7",NcGroup::ChildrenAndCurrent).isNull())throw NcException("Error in test 9.20",__FILE__,__LINE__);
+        if( ncFile.getDim("dim1",NcGroup::All).getName() !="dim1") throw NcException("Error in test 9.1",__FILE__,__LINE__);
+        if( ncFile.getDim("dim2",NcGroup::All).getName() !="dim2") throw NcException("Error in test 9.2",__FILE__,__LINE__);
+        if( ncFile.getDim("dim3",NcGroup::All).getName() !="dim3") throw NcException("Error in test 9.3",__FILE__,__LINE__);
+        if( ncFile.getDim("dim4",NcGroup::All).getName() !="dim4") throw NcException("Error in test 9.4",__FILE__,__LINE__);
+        if( ncFile.getDim("dim5",NcGroup::All).getName() !="dim5") throw NcException("Error in test 9.5",__FILE__,__LINE__);
+        if( ncFile.getDim("dim6",NcGroup::All).getName() !="dim6") throw NcException("Error in test 9.6",__FILE__,__LINE__);
+        if( ncFile.getDim("dim7",NcGroup::All).getName() !="dim7") throw NcException("Error in test 9.7",__FILE__,__LINE__);
+        if( groupB.getDim("dim1",NcGroup::All).getName() !="dim1") throw NcException("Error in test 9.8",__FILE__,__LINE__);
+        if( groupB.getDim("dim2",NcGroup::All).getName() !="dim2") throw NcException("Error in test 9.9",__FILE__,__LINE__);
+        if( groupB.getDim("dim3",NcGroup::All).getName() !="dim3") throw NcException("Error in test 9.10",__FILE__,__LINE__);
+        if( groupB.getDim("dim4",NcGroup::All).getName() !="dim4") throw NcException("Error in test 9.11",__FILE__,__LINE__);
+        if( groupB.getDim("dim5",NcGroup::All).getName() !="dim5") throw NcException("Error in test 9.12",__FILE__,__LINE__);
+        if( groupB.getDim("dim6",NcGroup::All).getName() !="dim6") throw NcException("Error in test 9.13",__FILE__,__LINE__);
+        if( groupB.getDim("dim7",NcGroup::All).getName() !="dim7") throw NcException("Error in test 9.14",__FILE__,__LINE__);
+        if( !ncFile.getDim("dim7").isNull())                            throw NcException("Error in test 9.15",__FILE__,__LINE__);
+        if( !ncFile.getDim("dim7",NcGroup::Current).isNull())           throw NcException("Error in test 9.16",__FILE__,__LINE__);
+        if( !ncFile.getDim("dim7",NcGroup::Parents).isNull())           throw NcException("Error in test 9.17",__FILE__,__LINE__);
+        if(  ncFile.getDim("dim7",NcGroup::Children).isNull())          throw NcException("Error in test 9.18",__FILE__,__LINE__);
+        if( !ncFile.getDim("dim7",NcGroup::ParentsAndCurrent).isNull()) throw NcException("Error in test 9.19",__FILE__,__LINE__);
+        if(  ncFile.getDim("dim7",NcGroup::ChildrenAndCurrent).isNull())throw NcException("Error in test 9.20",__FILE__,__LINE__);
 
-	if( !groupA.getDim("dim7").isNull())                            throw NcException("Error in test 9.21",__FILE__,__LINE__);
-	if( !groupA.getDim("dim7",NcGroup::Current).isNull())           throw NcException("Error in test 9.22",__FILE__,__LINE__);
-	if( !groupA.getDim("dim7",NcGroup::Parents).isNull())           throw NcException("Error in test 9.23",__FILE__,__LINE__);
-	if(  groupA.getDim("dim7",NcGroup::Children).isNull())          throw NcException("Error in test 9.24",__FILE__,__LINE__);
-	if( !groupA.getDim("dim7",NcGroup::ParentsAndCurrent).isNull()) throw NcException("Error in test 9.25",__FILE__,__LINE__);
-	if(  groupA.getDim("dim7",NcGroup::ChildrenAndCurrent).isNull())throw NcException("Error in test 9.26",__FILE__,__LINE__);
-	if(  groupA.getDim("dim7",NcGroup::All).isNull())               throw NcException("Error in test 9.27",__FILE__,__LINE__);
+        if( !groupA.getDim("dim7").isNull())                            throw NcException("Error in test 9.21",__FILE__,__LINE__);
+        if( !groupA.getDim("dim7",NcGroup::Current).isNull())           throw NcException("Error in test 9.22",__FILE__,__LINE__);
+        if( !groupA.getDim("dim7",NcGroup::Parents).isNull())           throw NcException("Error in test 9.23",__FILE__,__LINE__);
+        if(  groupA.getDim("dim7",NcGroup::Children).isNull())          throw NcException("Error in test 9.24",__FILE__,__LINE__);
+        if( !groupA.getDim("dim7",NcGroup::ParentsAndCurrent).isNull()) throw NcException("Error in test 9.25",__FILE__,__LINE__);
+        if(  groupA.getDim("dim7",NcGroup::ChildrenAndCurrent).isNull())throw NcException("Error in test 9.26",__FILE__,__LINE__);
+        if(  groupA.getDim("dim7",NcGroup::All).isNull())               throw NcException("Error in test 9.27",__FILE__,__LINE__);
 
-	if(  groupB.getDim("dim7").isNull())                            throw NcException("Error in test 9.28",__FILE__,__LINE__);
-	if(  groupB.getDim("dim7",NcGroup::Current).isNull())           throw NcException("Error in test 9.29",__FILE__,__LINE__);
-	if( !groupB.getDim("dim7",NcGroup::Parents).isNull())           throw NcException("Error in test 9.30",__FILE__,__LINE__);
-	if( !groupB.getDim("dim7",NcGroup::Children).isNull())          throw NcException("Error in test 9.31",__FILE__,__LINE__);
-	if(  groupB.getDim("dim7",NcGroup::ParentsAndCurrent).isNull()) throw NcException("Error in test 9.32",__FILE__,__LINE__);
-	if(  groupB.getDim("dim7",NcGroup::ChildrenAndCurrent).isNull())throw NcException("Error in test 9.33",__FILE__,__LINE__);
-	if(  groupB.getDim("dim7",NcGroup::All).isNull())               throw NcException("Error in test 9.34",__FILE__,__LINE__);
-	if( !ncFile.getDim("dimX",NcGroup::All).isNull())               throw NcException("Error in test 9.35",__FILE__,__LINE__);
+        if(  groupB.getDim("dim7").isNull())                            throw NcException("Error in test 9.28",__FILE__,__LINE__);
+        if(  groupB.getDim("dim7",NcGroup::Current).isNull())           throw NcException("Error in test 9.29",__FILE__,__LINE__);
+        if( !groupB.getDim("dim7",NcGroup::Parents).isNull())           throw NcException("Error in test 9.30",__FILE__,__LINE__);
+        if( !groupB.getDim("dim7",NcGroup::Children).isNull())          throw NcException("Error in test 9.31",__FILE__,__LINE__);
+        if(  groupB.getDim("dim7",NcGroup::ParentsAndCurrent).isNull()) throw NcException("Error in test 9.32",__FILE__,__LINE__);
+        if(  groupB.getDim("dim7",NcGroup::ChildrenAndCurrent).isNull())throw NcException("Error in test 9.33",__FILE__,__LINE__);
+        if(  groupB.getDim("dim7",NcGroup::All).isNull())               throw NcException("Error in test 9.34",__FILE__,__LINE__);
+        if( !ncFile.getDim("dimX",NcGroup::All).isNull())               throw NcException("Error in test 9.35",__FILE__,__LINE__);
       }
 
       cout <<"    -----------   passed\n";
@@ -376,7 +376,7 @@ int main()
       {
         NcDim dim;
         NcVar var;
-        
+
         ncFile.getCoordVar("dim1", dim, var, NcGroup::Current);
         if (dim.getName() != "dim1" || var.getName() != "dim1") throw NcException("Error in test 11.1", __FILE__, __LINE__);
         ncFile.getCoordVar("dim1", dim, var, NcGroup::Parents);


### PR DESCRIPTION
Fixes #120 