### PR TITLE
Report test errors correctly

### DIFF
--- a/cxx4/example1.cpp
+++ b/cxx4/example1.cpp
@@ -36,7 +36,7 @@ try
   }
  catch (NcException& e)
    {
-     cout << "unknown error"<<endl;
-     e.what();
+     cout << e.what() << endl;
+     return EXIT_FAILURE;
    }
 }

--- a/cxx4/test_att.cpp
+++ b/cxx4/test_att.cpp
@@ -828,8 +828,7 @@ int main()
     }
   catch (NcException& e)
     {
-      cout << "unknown error"<<endl;
-      e.what();
-      return e.errorCode();
+      cout << e.what() << endl;
+      return EXIT_FAILURE;
     }
 }

--- a/cxx4/test_classic.cpp
+++ b/cxx4/test_classic.cpp
@@ -52,7 +52,7 @@ int main()
    }
    catch(NcException& e)
    {
-      cout << "Error!\n";
-      return e.errorCode();
+     cout << e.what() << endl;
+     return EXIT_FAILURE;
    }
 }

--- a/cxx4/test_dim.cpp
+++ b/cxx4/test_dim.cpp
@@ -326,8 +326,7 @@ int main()
     }
   catch (NcException& e)
     {
-      cout <<"\n";
-      e.what();
-      return e.errorCode();
+      cout << e.what() << endl;
+      return EXIT_FAILURE;
     }
 }

--- a/cxx4/test_filter.cpp
+++ b/cxx4/test_filter.cpp
@@ -70,8 +70,7 @@ int main()
     }
   catch (NcException& e)
     {
-      cout << "unknown error"<<endl;
-      e.what();
+      cout << e.what() << endl;
       return e.errorCode();
     }
 }

--- a/cxx4/test_group.cpp
+++ b/cxx4/test_group.cpp
@@ -386,8 +386,7 @@ try
   }
  catch (NcException& e)
    {
-     cout << "unknown error"<<endl;
-     e.what();
-     return e.errorCode();
+      cout << e.what() << endl;
+      return EXIT_FAILURE;
    }
 }

--- a/cxx4/test_type.cpp
+++ b/cxx4/test_type.cpp
@@ -530,7 +530,6 @@ try
       vlenPointer[0] = 1;
       vlenPointer[1] = 31;
       vlenPointer[2] = -20;
-      dummyData2.mem1[0];
       dummyData2.mem1[0].p = vlenPointer;
       dummyData2.mem1[0].len=3;
       //      vlenPointer = new short int[2];
@@ -558,8 +557,7 @@ try
 }
 catch (NcException& e)
   {
-    cout << "unknown error"<<endl;
-    cout << e.what();
-    exit(e.errorCode());
+      cout << e.what() << endl;
+      return EXIT_FAILURE;
   }
 }

--- a/cxx4/test_type2.cpp
+++ b/cxx4/test_type2.cpp
@@ -53,8 +53,7 @@ try
 }
 catch (NcException& e)
   {
-    cout << "unknown error"<<endl;
-    e.what();
+    cout << e.what() << endl;
     return e.errorCode();
   }
 }

--- a/cxx4/test_type3.cpp
+++ b/cxx4/test_type3.cpp
@@ -88,8 +88,7 @@ try
   }
  catch (NcException& e)
    {
-     cout << "unknown error"<<endl;
-     e.what();
+     cout << e.what() << endl;
      return e.errorCode();
    }
 }

--- a/cxx4/test_type4.cpp
+++ b/cxx4/test_type4.cpp
@@ -72,8 +72,7 @@ try
   }
  catch (NcException& e)
    {
-     cout << "unknown error"<<endl;
-     e.what();
+     cout << e.what() << endl;
      return e.errorCode();
    }
 }

--- a/cxx4/test_type5.cpp
+++ b/cxx4/test_type5.cpp
@@ -78,8 +78,7 @@ try
   }
  catch (NcException& e)
    {
-     cout << "unknown error"<<endl;
-     e.what();
+     cout << e.what() << endl;
      return e.errorCode();
    }
 }

--- a/cxx4/test_var.cpp
+++ b/cxx4/test_var.cpp
@@ -811,8 +811,7 @@ int main()
     }
   catch (NcException& e)
     {
-      cout << "unknown error"<<endl;
-      e.what();
-      return e.errorCode();
+      cout << e.what() << endl;
+      return EXIT_FAILURE;
     }
 }

--- a/cxx4/test_var2.cpp
+++ b/cxx4/test_var2.cpp
@@ -186,8 +186,7 @@ int main()
     }
   catch (NcException& e)
     {
-      cout << "unknown error"<<endl;
-      e.what();
-      return e.errorCode();
+      cout << e.what() << endl;
+      return EXIT_FAILURE;
     }
 }

--- a/examples/pres_temp_4D_plugin_rd.cpp
+++ b/examples/pres_temp_4D_plugin_rd.cpp
@@ -116,8 +116,8 @@ int main()
    }
    catch(NcException& e)
    {
-      e.what();
-      cout<<"FAILURE**************************"<<endl;
+      cout<<"FAILURE**************************\n";
+      cout << e.what() << endl;
       return NC_ERR;
    }
   

--- a/examples/pres_temp_4D_plugin_wr.cpp
+++ b/examples/pres_temp_4D_plugin_wr.cpp
@@ -189,7 +189,8 @@ int main()
    }
    catch(NcException& e)
    {
-      e.what();
+      cout<<"FAILURE**************************\n";
+      cout << e.what() << endl;
       return NC_ERR;
    }
 }

--- a/examples/pres_temp_4D_rd.cpp
+++ b/examples/pres_temp_4D_rd.cpp
@@ -116,8 +116,8 @@ int main()
    }
    catch(NcException& e)
    {
-      e.what();
-      cout<<"FAILURE**************************"<<endl;
+      cout<<"FAILURE**************************\n";
+      cout << e.what() << endl;
       return NC_ERR;
    }
   

--- a/examples/pres_temp_4D_wr.cpp
+++ b/examples/pres_temp_4D_wr.cpp
@@ -162,7 +162,8 @@ int main()
    }
    catch(NcException& e)
    {
-      e.what(); 
+      cout<<"FAILURE**************************\n";
+      cout << e.what() << endl;
       return NC_ERR;
    }
 }

--- a/examples/sfc_pres_temp_rd.cpp
+++ b/examples/sfc_pres_temp_rd.cpp
@@ -149,7 +149,7 @@ int main(void)
    //cout << "*** SUCCESS reading example file sfc_pres_temp.nc!" << endl;
    return 0;
   }
-  catch(NcException e)
+  catch(NcException& e)
   {
       cout<<"FAILURE**************************\n";
       cout << e.what() << endl;

--- a/examples/sfc_pres_temp_rd.cpp
+++ b/examples/sfc_pres_temp_rd.cpp
@@ -151,8 +151,8 @@ int main(void)
   }
   catch(NcException e)
   {
-     e.what();
-     cout<<"FAILURE********************************8"<<endl;
-     return NC_ERR;
+      cout<<"FAILURE**************************\n";
+      cout << e.what() << endl;
+      return NC_ERR;
   }
 }

--- a/examples/sfc_pres_temp_wr.cpp
+++ b/examples/sfc_pres_temp_wr.cpp
@@ -138,7 +138,8 @@ int main(void)
    }
    catch(NcException& e)
      {
-      e.what(); 
+      cout<<"FAILURE**************************\n";
+      cout << e.what() << endl;
       return NC_ERR;
    }
 }

--- a/examples/simple_xy_rd.cpp
+++ b/examples/simple_xy_rd.cpp
@@ -54,8 +54,8 @@ int main()
    return 0;
    }catch(NcException& e)
      {
-       e.what();
-       cout<<"FAILURE*************************************"<<endl;
-       return NC_ERR;
+      cout<<"FAILURE**************************\n";
+      cout << e.what() << endl;
+      return NC_ERR;
      }
 }

--- a/examples/simple_xy_wr.cpp
+++ b/examples/simple_xy_wr.cpp
@@ -76,7 +76,9 @@ int main()
       return 0; 
     }
   catch(NcException& e)
-    {e.what();
+    {
+      cout<<"FAILURE**************************\n";
+      cout << e.what() << endl;
       return NC_ERR;
     }
 }

--- a/examples/simple_xy_wr_formats.cpp
+++ b/examples/simple_xy_wr_formats.cpp
@@ -78,7 +78,9 @@ int create_file(string filename, NcFile::FileFormat format) {
       return 0; 
     }
   catch(NcException& e)
-    {e.what();
+    {
+      cout<<"FAILURE**************************\n";
+      cout << e.what() << endl;
       return NC_ERR;
     }
 }


### PR DESCRIPTION
Most of the tests were catching exceptions are calling `e.what()` and discarding the result. Also, a lot of the tests were returning `e.errorCode()`, but unfortunately throwing the form of `NcException` where `e.errorCode() == 0`.

Two things to consider: 
1. defaulting `NcException::ec` to `EXIT_FAILURE` or other non-zero value.
2. using a testing framework like googletest or catch2. The current tests report a maximum of one error per test, but with one of those frameworks, multiple errors could be caught per run.