### PR TITLE
removed g_ncid as the ascociated bug was fixed in c library 4.4.1

### DIFF
--- a/cxx4/ncFile.cpp
+++ b/cxx4/ncFile.cpp
@@ -9,7 +9,6 @@ using namespace std;
 using namespace netCDF;
 using namespace netCDF::exceptions;
 
-int g_ncid = -1;
 
 // destructor
 NcFile::~NcFile()
@@ -31,7 +30,6 @@ void NcFile::close()
 {
   if (!nullObject) {
     ncCheck(nc_close(myId),__FILE__,__LINE__);
-    g_ncid = -1;
   }
 
   nullObject = true;
@@ -65,7 +63,6 @@ void NcFile::open(const string& filePath, int ncFileFlags) {
     close();
 
   ncCheck(nc_open(filePath.c_str(), ncFileFlags, &myId),__FILE__,__LINE__);
-  g_ncid = myId;
 
   nullObject=false;
 }
@@ -95,7 +92,6 @@ void NcFile::open(const string& filePath, const FileMode fMode)
       break;
     }
 
-  g_ncid = myId;
 
   nullObject=false;
 }
@@ -117,7 +113,6 @@ void NcFile::create(const string& filePath, const int ncFileFlags) {
 
   ncCheck(nc_create(filePath.c_str(),ncFileFlags,&myId),__FILE__,__LINE__);
 
-  g_ncid = myId;
 
   nullObject=false;
 }
@@ -159,7 +154,6 @@ void NcFile::open(const string& filePath, const FileMode fMode, const FileFormat
       break;
     }
 
-  g_ncid = myId;
   nullObject=false;
 }
 

--- a/cxx4/ncType.cpp
+++ b/cxx4/ncType.cpp
@@ -4,7 +4,6 @@
 #include "ncCheck.h"
 using namespace std;
 
-extern int g_ncid;
 
 namespace netCDF {
   //  Global comparator operator ==============
@@ -99,7 +98,7 @@ string  NcType::getName() const{
      netcdf file ID (ncid), which is not *groupid*.
      Working around this for now. */
 
-  ncCheck(nc_inq_type(g_ncid,myId,charName,sizep),__FILE__,__LINE__);
+  ncCheck(nc_inq_type(groupId,myId,charName,sizep),__FILE__,__LINE__);
   return string(charName);
 
 };
@@ -108,7 +107,7 @@ string  NcType::getName() const{
 size_t NcType::getSize() const{
   char* charName=NULL;
   size_t sizep;
-  ncCheck(nc_inq_type(g_ncid,myId,charName,&sizep),__FILE__,__LINE__);
+  ncCheck(nc_inq_type(groupId,myId,charName,&sizep),__FILE__,__LINE__);
   return sizep;
 };
 

--- a/cxx4/ncType.h
+++ b/cxx4/ncType.h
@@ -151,12 +151,6 @@ namespace netCDF
     /*! the group Id */
     int groupId;
 
-    /*! An ncid associated with a particular open file
-      (returned from nc_open).
-      This is required by many of the functions ncType uses,
-      such as nc_inq_type */
-    int g_fileId;
-
   };
 
 }


### PR DESCRIPTION
Fixes #32 #30 
Hi, So I have been digging into the global variable issue, it appears it was fixed in the C library in 2016.

specifically It seems like this was fixed in the netcdf-c 4.4.1 library:
https://github.com/Unidata/netcdf-c/issues/240

If my understanding is correct, as it stands anyone using netcdf4 and defining custom types cannot have more than one file open at the same time. It also forces the custom type definition to be in the root group for netcdf4, rather than the parent group as one would expect.

I think the correct solution is to get rid of the global variable g_ncid and replace it with the groupID when calling nc_inq_type, though I am not sure what version compatibility you are targeting between this and netcdf-c.