### PR TITLE
Fix filter test

### DIFF
--- a/cxx4/test_filter.cpp
+++ b/cxx4/test_filter.cpp
@@ -51,22 +51,12 @@ int main()
       latVar.setChunking(NcVar::nc_CHUNKED,chunks);
 
       cout<<"Setting Filter....";
-      try{
-        latVar.setFilter(BZIP2_ID,BZIP2_NPARAMS,&level);
-        cout<<"Success."<<endl;
-      } catch (NcException &e){
-        cout<<"Caught unexpected exception." << endl;
-        return e.errorCode();
-      }
+      latVar.setFilter(BZIP2_ID,BZIP2_NPARAMS,&level);
+      cout<<"Success\n";
 
       cout<<"Getting filter...";
-      try{
-        latVar.getFilter(&idp,&nparamsp, &level);
-        cout<<"Success."<<endl;
-      } catch (NcException &e){
-        cout<<"Caught unexpected exception." << endl;
-        return e.errorCode();
-      }
+      latVar.getFilter(&idp,&nparamsp, &level);
+      cout<<"Success\n";
     }
   catch (NcException& e)
     {

--- a/cxx4/test_filter.cpp
+++ b/cxx4/test_filter.cpp
@@ -5,6 +5,7 @@
 #include <ncFile.h>
 #include <ncVar.h>
 #include <ncException.h>
+#include <netcdf_filter.h>
 #include <string>
 #include <netcdf>
 #include "test_utilities.h"
@@ -51,7 +52,7 @@ int main()
       latVar.setChunking(NcVar::nc_CHUNKED,chunks);
 
       cout<<"Setting Filter....";
-      latVar.setFilter(BZIP2_ID,BZIP2_NPARAMS,&level);
+      latVar.setFilter(H5Z_FILTER_DEFLATE, BZIP2_NPARAMS, &level);
       cout<<"Success\n";
 
       cout<<"Getting filter...";


### PR DESCRIPTION
Fixes #134 

Main fix is to use `H5Z_FILTER_DEFLATE` instead of bzip2, as deflate should always be available.

Also check the return values of `getFilter`