### PR TITLE
Add `NcType::isNonPrimitive()` helper function to reduce duplication

### DIFF
--- a/cxx4/ncGroup.cpp
+++ b/cxx4/ncGroup.cpp
@@ -630,8 +630,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const string& dataValues) const {
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, const unsigned char* dataValues) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_uchar(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
@@ -643,8 +642,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, c
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, const signed char* dataValues) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_schar(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
@@ -656,8 +654,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, c
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, short datumValue) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_short(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
@@ -669,8 +666,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, short datumVa
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, int datumValue) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_int(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
@@ -681,8 +677,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, int datumValu
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, long datumValue) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_long(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
@@ -693,8 +688,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, long datumVal
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, float datumValue) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_float(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
@@ -706,8 +700,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, float datumVa
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, double datumValue) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_double(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
@@ -719,8 +712,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, double datumV
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, unsigned short datumValue) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_ushort(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
@@ -731,8 +723,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, unsigned shor
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, unsigned int datumValue) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_uint(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
@@ -743,8 +734,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, unsigned int 
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, long long datumValue) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_longlong(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
@@ -756,8 +746,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, long long dat
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, unsigned long long datumValue) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_ulonglong(myId,NC_GLOBAL,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
@@ -769,8 +758,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, unsigned long
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, const short* dataValues) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_short(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
@@ -782,8 +770,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, c
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, const int* dataValues) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_int(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
@@ -794,8 +781,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, c
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, const long* dataValues) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_long(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
@@ -806,8 +792,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, c
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, const float* dataValues) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_float(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
@@ -819,8 +804,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, c
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, const double* dataValues) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_double(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
@@ -832,8 +816,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, c
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, const unsigned short* dataValues) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_ushort(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
@@ -844,8 +827,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, c
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, const unsigned int* dataValues) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_uint(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
@@ -856,8 +838,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, c
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, const long long* dataValues) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_longlong(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
@@ -869,8 +850,7 @@ NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, c
 //  Creates a new NetCDF group attribute or if already exisiting replaces it.
 NcGroupAtt NcGroup::putAtt(const string& name, const NcType& type, size_t len, const unsigned long long* dataValues) const {
   ncCheckDefineMode(myId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive())
     ncCheck(nc_put_att(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_att_ulonglong(myId,NC_GLOBAL,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);

--- a/cxx4/ncType.cpp
+++ b/cxx4/ncType.cpp
@@ -164,3 +164,13 @@ string NcType::getTypeClassName() const{
   // we never get here!
   return "Dummy";
 }
+
+bool NcType::isNonPrimitive() const {
+  NcType::ncType typeClass {getTypeClass()};
+  return (
+    typeClass == NcType::nc_VLEN
+    || typeClass == NcType::nc_OPAQUE
+    || typeClass == NcType::nc_ENUM
+    || typeClass == NcType::nc_COMPOUND
+  );
+}

--- a/cxx4/ncType.h
+++ b/cxx4/ncType.h
@@ -129,6 +129,9 @@ namespace netCDF
      */
     std::string getTypeClassName() const;
 
+    /*! Return true if this is not a primitive type */
+    bool isNonPrimitive() const;
+
     /*! Returns true if this object is null (i.e. it has no contents); otherwise returns false. */
     bool isNull() const  {return nullObject;}
 

--- a/cxx4/ncVar.cpp
+++ b/cxx4/ncVar.cpp
@@ -225,7 +225,6 @@ NcVarAtt NcVar::getAtt(const string& name) const
 
 /////////////////////////
 
-
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const string& dataValues) const {
   ncCheckDefineMode(groupId);
@@ -237,11 +236,11 @@ NcVarAtt NcVar::putAtt(const string& name, const string& dataValues) const {
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const unsigned char* dataValues) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_uchar(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -250,11 +249,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const signed char* dataValues) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_schar(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -265,11 +264,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, short datumValue) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_short(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -278,11 +277,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, short datumValue)
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, int datumValue) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_int(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -290,11 +289,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, int datumValue) c
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, long datumValue) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_long(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -302,11 +301,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, long datumValue) 
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, float datumValue) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_float(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -315,11 +314,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, float datumValue)
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, double datumValue) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_double(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -328,11 +327,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, double datumValue
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, unsigned short datumValue) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_ushort(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -340,11 +339,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, unsigned short da
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, unsigned int datumValue) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_uint(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -352,11 +351,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, unsigned int datu
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, long long datumValue) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_longlong(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -365,11 +364,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, long long datumVa
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, unsigned long long datumValue) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_ulonglong(groupId,myId,name.c_str(),type.getId(),1,&datumValue),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -390,11 +389,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, unsigned long lon
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const short* dataValues) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_short(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -403,11 +402,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const int* dataValues) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_int(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -415,11 +414,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const long* dataValues) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_long(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -427,11 +426,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const float* dataValues) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_float(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -440,11 +439,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const double* dataValues) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_double(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -453,11 +452,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const unsigned short* dataValues) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_ushort(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -465,11 +464,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const unsigned int* dataValues) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_uint(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -477,11 +476,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const long long* dataValues) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
-  else
+  } else {
     ncCheck(nc_put_att_longlong(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -490,11 +489,11 @@ NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const
 // Creates a new NetCDF variable attribute or if already exisiting replaces it.
 NcVarAtt NcVar::putAtt(const string& name, const NcType& type, size_t len, const unsigned long long* dataValues) const {
   ncCheckDefineMode(groupId);
-  NcType::ncType typeClass(type.getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (type.isNonPrimitive()) {
     ncCheck(nc_put_att(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
-  else
-    ncCheck(nc_put_att_ulonglong(groupId,myId,name.c_str(),type.getId(),len,dataValues),__FILE__,__LINE__);
+  } else {
+    ncCheck(nc_put_att_ulonglong(groupId,myId,name.c_str(),type.getId(),len,dataValues), __FILE__, __LINE__);
+  }
   // finally instantiate this attribute and return
   return getAtt(name);
 }
@@ -726,8 +725,7 @@ void NcVar::rename( const string& newname ) const
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_text(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -735,8 +733,7 @@ void NcVar::putVar(const char* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const unsigned char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_uchar(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -744,8 +741,7 @@ void NcVar::putVar(const unsigned char* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const signed char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_schar(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -753,8 +749,7 @@ void NcVar::putVar(const signed char* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const short* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_short(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -762,8 +757,7 @@ void NcVar::putVar(const short* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const int* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_int(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -771,8 +765,7 @@ void NcVar::putVar(const int* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_long(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -780,8 +773,7 @@ void NcVar::putVar(const long* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const float* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_float(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -789,8 +781,7 @@ void NcVar::putVar(const float* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const double* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_double(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -798,8 +789,7 @@ void NcVar::putVar(const double* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const unsigned short* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_ushort(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -807,8 +797,7 @@ void NcVar::putVar(const unsigned short* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const unsigned int* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_uint(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -816,8 +805,7 @@ void NcVar::putVar(const unsigned int* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const long long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_longlong(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -825,8 +813,7 @@ void NcVar::putVar(const long long* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const unsigned long long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_ulonglong(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -834,8 +821,7 @@ void NcVar::putVar(const unsigned long long* dataValues) const {
 // Writes the entire data into the netCDF variable.
 void NcVar::putVar(const char** dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var_string(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -851,8 +837,7 @@ void NcVar::putVar(const void* dataValues) const {
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const string& datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     throw NcException("user-defined type must be of type void",__FILE__,__LINE__);
   else
     {
@@ -863,8 +848,7 @@ void NcVar::putVar(const vector<size_t>& index, const string& datumValue) const 
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const unsigned char* datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     throw NcException("user-defined type must be of type void",__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_uchar(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
@@ -872,8 +856,7 @@ void NcVar::putVar(const vector<size_t>& index, const unsigned char* datumValue)
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const signed char* datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     throw NcException("user-defined type must be of type void",__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_schar(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
@@ -881,8 +864,7 @@ void NcVar::putVar(const vector<size_t>& index, const signed char* datumValue) c
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const short datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var1(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_short(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
@@ -890,8 +872,7 @@ void NcVar::putVar(const vector<size_t>& index, const short datumValue) const {
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const int datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var1(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_int(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
@@ -899,8 +880,7 @@ void NcVar::putVar(const vector<size_t>& index, const int datumValue) const {
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const long datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var1(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_long(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
@@ -908,8 +888,7 @@ void NcVar::putVar(const vector<size_t>& index, const long datumValue) const {
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const float datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var1(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_float(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
@@ -917,8 +896,7 @@ void NcVar::putVar(const vector<size_t>& index, const float datumValue) const {
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const double datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var1(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_double(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
@@ -926,8 +904,7 @@ void NcVar::putVar(const vector<size_t>& index, const double datumValue) const {
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const unsigned short datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var1(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_ushort(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
@@ -935,8 +912,7 @@ void NcVar::putVar(const vector<size_t>& index, const unsigned short datumValue)
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const unsigned int datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var1(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_uint(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
@@ -944,8 +920,7 @@ void NcVar::putVar(const vector<size_t>& index, const unsigned int datumValue) c
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const long long datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var1(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_longlong(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
@@ -953,8 +928,7 @@ void NcVar::putVar(const vector<size_t>& index, const long long datumValue) cons
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const unsigned long long datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_var1(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_ulonglong(groupId, myId,&index[0],&datumValue),__FILE__,__LINE__);
@@ -962,8 +936,7 @@ void NcVar::putVar(const vector<size_t>& index, const unsigned long long datumVa
 // Writes a single datum value into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& index, const char** datumValue) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     throw NcException("user-defined type must be of type void",__FILE__,__LINE__);
   else
     ncCheck(nc_put_var1_string(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
@@ -980,8 +953,7 @@ void NcVar::putVar(const vector<size_t>& index, const void* datumValue) const {
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_text(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -989,8 +961,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const unsigned char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_uchar(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -998,8 +969,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const signed char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_schar(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1007,8 +977,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const short* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_short(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1016,8 +985,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const int* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_int(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1025,8 +993,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_long(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1034,8 +1001,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const float* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_float(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1043,8 +1009,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const double* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_double(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1052,8 +1017,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const unsigned short* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_ushort(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1061,8 +1025,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const unsigned int* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_uint(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1070,8 +1033,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const long long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_longlong(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1079,8 +1041,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const unsigned long long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_ulonglong(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1088,8 +1049,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes an array of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, const char** dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vara_string(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1107,8 +1067,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_text(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1116,8 +1075,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const unsigned char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_uchar(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1125,8 +1083,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const signed char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_schar(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1134,8 +1091,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const short* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_short(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1143,8 +1099,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const int* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_int(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1152,8 +1107,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_long(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1161,8 +1115,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const float* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_float(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1170,8 +1123,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const double* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_double(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1179,8 +1131,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const unsigned short* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_ushort(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1188,8 +1139,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const unsigned int* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_uint(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1197,8 +1147,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const long long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_longlong(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1206,8 +1155,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const unsigned long long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_ulonglong(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1215,8 +1163,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a set of subsampled array values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep,  const char** dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_vars_string(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1232,8 +1179,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_text(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1241,8 +1187,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const unsigned char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_uchar(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1250,8 +1195,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const signed char* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_schar(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1259,8 +1203,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const short* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_short(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1268,8 +1211,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const int* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_int(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1277,8 +1219,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_long(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1286,8 +1227,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const float* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_float(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1295,8 +1235,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const double* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_double(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1304,8 +1243,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const unsigned short* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_ushort(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1313,8 +1251,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const unsigned int* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_uint(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1322,8 +1259,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const long long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_longlong(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1331,8 +1267,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const unsigned long long* dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_ulonglong(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1340,8 +1275,7 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 // Writes a mapped array section of values into the netCDF variable.
 void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, const char** dataValues) const {
   ncCheckDataMode(groupId);
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_put_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_put_varm_string(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1362,104 +1296,91 @@ void NcVar::putVar(const vector<size_t>& startp, const vector<size_t>&countp, co
 
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_text(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(unsigned char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_uchar(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(signed char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_schar(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(short* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_short(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(int* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_int(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_long(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(float* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_float(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(double* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_double(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(unsigned short* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_ushort(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(unsigned int* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_uint(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(long long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_longlong(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(unsigned long long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_ulonglong(groupId, myId,dataValues),__FILE__,__LINE__);
 }
 // Reads the entire data of the netCDF variable.
 void NcVar::getVar(char** dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var(groupId, myId,dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var_string(groupId, myId,dataValues),__FILE__,__LINE__);
@@ -1475,104 +1396,91 @@ void NcVar::getVar(void* dataValues) const {
 
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, char* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_text(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, unsigned char* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_uchar(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, signed char* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_schar(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, short* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_short(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, int* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_int(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, long* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_long(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, float* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_float(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, double* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_double(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, unsigned short* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_ushort(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, unsigned int* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_uint(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, long long* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_longlong(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable
 void NcVar::getVar(const vector<size_t>& index, unsigned long long* datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_ulonglong(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
 }
 // Reads a single datum value of a netCDF variable.
 void NcVar::getVar(const vector<size_t>& index, char** datumValue) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_var1(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
   else
     ncCheck(nc_get_var1_string(groupId, myId,&index[0],datumValue),__FILE__,__LINE__);
@@ -1588,104 +1496,91 @@ void NcVar::getVar(const vector<size_t>& index, void* datumValue) const {
 
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_text(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, unsigned char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_uchar(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, signed char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_schar(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, short* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_short(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, int* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_int(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_long(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, float* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_float(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, double* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_double(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, unsigned short* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_ushort(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, unsigned int* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_uint(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, long long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_longlong(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, unsigned long long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_ulonglong(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads an array of values from  a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, char** dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vara(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vara_string(groupId, myId,&startp[0],&countp[0],dataValues),__FILE__,__LINE__);
@@ -1700,104 +1595,91 @@ void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, v
 
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_text(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, unsigned char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_uchar(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, signed char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_schar(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, short* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_short(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, int* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_int(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_long(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, float* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_float(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, double* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_double(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, unsigned short* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_ushort(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, unsigned int* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_uint(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, long long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_longlong(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, unsigned long long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_ulonglong(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a subsampled (strided) array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, char** dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_vars(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_vars_string(groupId, myId,&startp[0],&countp[0],&stridep[0],dataValues),__FILE__,__LINE__);
@@ -1812,64 +1694,56 @@ void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 
 // Reads a mapped array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_text(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a mapped array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, unsigned char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_uchar(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a mapped array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, signed char* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_schar(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a mapped array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, short* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_short(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a mapped array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, int* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_int(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a mapped array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_long(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a mapped array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, float* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_float(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a mapped array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, double* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_double(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
@@ -1884,32 +1758,28 @@ void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, c
 }
 // Reads a mapped array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, unsigned int* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_uint(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a mapped array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, long long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_longlong(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a mapped array section of values from a netCDF variable
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, unsigned long long* dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_ulonglong(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
 }
 // Reads a mapped array section of values from a netCDF variable.
 void NcVar::getVar(const vector<size_t>& startp, const vector<size_t>& countp, const vector<ptrdiff_t>& stridep, const vector<ptrdiff_t>& imapp, char** dataValues) const {
-  NcType::ncType typeClass(getType().getTypeClass());
-  if(typeClass == NcType::nc_VLEN || typeClass == NcType::nc_OPAQUE || typeClass == NcType::nc_ENUM || typeClass == NcType::nc_COMPOUND)
+  if (getType().isNonPrimitive())
     ncCheck(nc_get_varm(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);
   else
     ncCheck(nc_get_varm_string(groupId, myId,&startp[0],&countp[0],&stridep[0],&imapp[0],dataValues),__FILE__,__LINE__);


### PR DESCRIPTION
Probably even better would be to add a helper functions for `nc_put_att*` to remove the duplicated methods between `NcGroup::putAtt` and `NcVar::putAtt`