### PR TITLE
Default or delete most constructors/assignment operators

### DIFF
--- a/cxx4/ncAtt.cpp
+++ b/cxx4/ncAtt.cpp
@@ -6,39 +6,6 @@
 using namespace std;
 using namespace netCDF;
   
-
-// destructor  (defined even though it is virtual)
-NcAtt::~NcAtt() {}
-
-// assignment operator
-NcAtt& NcAtt::operator=(const NcAtt& rhs)
-{
-  nullObject = rhs.nullObject;
-  myName = rhs.myName;
-  groupId = rhs.groupId;
-  varId =rhs.varId;
-  return *this;
-}
-
-// Constructor generates a null object.
-NcAtt::NcAtt() : 
-  nullObject(true) 
-{}
-
-// Constructor for non-null instances.
-NcAtt::NcAtt(bool nullObject): 
-  nullObject(nullObject)
-{}
-
-// The copy constructor.
-NcAtt::NcAtt(const NcAtt& rhs) :
-  nullObject(rhs.nullObject),
-  myName(rhs.myName),
-  groupId(rhs.groupId),
-   varId(rhs.varId)
-{}
-
-
 // equivalence operator
 bool NcAtt::operator==(const NcAtt & rhs) const
 {

--- a/cxx4/ncAtt.h
+++ b/cxx4/ncAtt.h
@@ -14,17 +14,15 @@ namespace netCDF
   {
   public:
     
-    /*! destructor */
-    virtual ~NcAtt()=0;
-
     /*! Constructor generates a \ref isNull "null object". */
-    NcAtt ();
+    NcAtt () = default;
+    virtual ~NcAtt() = default;
+    NcAtt(const NcAtt& rhs) = default;
+    NcAtt(NcAtt&&) = default;
     
     /*! Constructor for non-null instances. */
-    NcAtt(bool nullObject); 
+    NcAtt(bool nullObject_) : nullObject(nullObject_) {}
 
-    /*! The copy constructor. */
-    NcAtt(const NcAtt& rhs);
 
     /*! Get the attribute name. */
     std::string getName() const {return myName;}
@@ -103,17 +101,13 @@ namespace netCDF
     bool isNull() const {return nullObject;}
 
   protected:
-    /*! assignment operator */
-    NcAtt& operator= (const NcAtt& rhs);
+    NcAtt& operator= (const NcAtt& rhs) = default;
+    NcAtt& operator= (NcAtt&&) = default;
       
-    bool nullObject;
-
+    bool nullObject{true};
     std::string myName;
-    
-    int groupId;
-      
-    int varId;
-    
+    int groupId{-1};
+    int varId{-1};
   };
   
 }

--- a/cxx4/ncByte.cpp
+++ b/cxx4/ncByte.cpp
@@ -11,11 +11,7 @@ namespace netCDF {
 NcByte::NcByte() : NcType(NC_BYTE){
 }
 
-NcByte::~NcByte() {
-}
-
 int NcByte::sizeoff(){char a;return sizeof(a);};
-
 
 // equivalence operator
 bool NcByte::operator==(const NcByte & rhs)    {

--- a/cxx4/ncByte.h
+++ b/cxx4/ncByte.h
@@ -17,8 +17,6 @@ namespace netCDF
     /*! storage size */
     int sizeoff();
 
-    ~NcByte();
-    
     /*! Constructor */
     NcByte();
   };

--- a/cxx4/ncChar.cpp
+++ b/cxx4/ncChar.cpp
@@ -11,10 +11,6 @@ namespace netCDF {
 NcChar::NcChar() : NcType(NC_CHAR){
 }
 
-NcChar::~NcChar() {
-}
-
-
 // equivalence operator
 bool NcChar::operator==(const NcChar & rhs)    {
   // simply check the netCDF id.

--- a/cxx4/ncChar.h
+++ b/cxx4/ncChar.h
@@ -13,10 +13,7 @@ namespace netCDF
     
     /*! equivalence operator */
     bool operator==(const NcChar & rhs);
-    
-    ~NcChar();
-    
-    /*! Constructor */
+
     NcChar();
   };
 

--- a/cxx4/ncCompoundType.cpp
+++ b/cxx4/ncCompoundType.cpp
@@ -22,13 +22,6 @@ using namespace netCDF::exceptions;
 // Class represents a netCDF variable.
 
 // assignment operator
-NcCompoundType& NcCompoundType::operator=(const NcCompoundType& rhs)
-{
-  NcType::operator=(rhs);    // assign base class parts
-  return *this;
-}
-
-// assignment operator
 NcCompoundType& NcCompoundType::operator=(const NcType& rhs)
 {
   if (&rhs != this) {
@@ -40,13 +33,6 @@ NcCompoundType& NcCompoundType::operator=(const NcType& rhs)
   return *this;
 }
 
-// The copy constructor.
-NcCompoundType::NcCompoundType(const NcCompoundType& rhs): 
-  NcType(rhs)
-{
-}
-
-
 // equivalence operator
 bool NcCompoundType::operator==(const NcCompoundType& rhs)
 {
@@ -55,11 +41,6 @@ bool NcCompoundType::operator==(const NcCompoundType& rhs)
   else
     return myId ==rhs.myId && groupId == rhs.groupId;
 }  
-  
-// Constructor generates a null object.
-NcCompoundType::NcCompoundType() : 
-  NcType()   // invoke base class constructor
-{}
   
 // constructor
 NcCompoundType::NcCompoundType(const NcGroup& grp, const string& name): 

--- a/cxx4/ncCompoundType.h
+++ b/cxx4/ncCompoundType.h
@@ -17,9 +17,12 @@ namespace netCDF
   class NcCompoundType : public NcType
   {
   public:
-
-    /*! Constructor generates a \ref isNull "null object". */
-    NcCompoundType();
+    NcCompoundType() = default;
+    ~NcCompoundType() = default;
+    NcCompoundType(const NcCompoundType& rhs) = default;
+    NcCompoundType(NcCompoundType&& rhs) = default;
+    NcCompoundType& operator=(const NcCompoundType& rhs) = default;
+    NcCompoundType& operator=(NcCompoundType&& rhs) = default;
 
     /*! 
       Constructor.
@@ -37,25 +40,15 @@ namespace netCDF
     */
     NcCompoundType(const NcType& ncType);
 
-    /*! assignment operator */
-    NcCompoundType& operator=(const NcCompoundType& rhs);
-      
     /*! 
       Assignment operator.
       This assigns from the base type NcType object. Will throw an exception if the NcType is not the base of a Compound type.
     */
     NcCompoundType& operator=(const NcType& rhs);
       
-    /*! The copy constructor. */
-    NcCompoundType(const NcCompoundType& rhs);
-      
     /*! equivalence operator */
     bool operator==(const NcCompoundType & rhs);
 
-    /*! destructor */
-    ~NcCompoundType(){;}
-      
-      
     /*!  
       Adds a named field.
       \param memName       Name of new field.

--- a/cxx4/ncDim.cpp
+++ b/cxx4/ncDim.cpp
@@ -22,23 +22,6 @@ namespace netCDF {
 
 using namespace netCDF;
 
-// assignment operator
-NcDim& NcDim::operator=(const NcDim & rhs)
-{
-  nullObject = rhs.nullObject;
-  myId = rhs.myId;
-  groupId = rhs.groupId;
-  return *this;
-}
-
-// The copy constructor.
-NcDim::NcDim(const NcDim& rhs):
-  nullObject(rhs.nullObject),
-  myId(rhs.myId),
-  groupId(rhs.groupId)
-{}
-
-
 // equivalence operator
 bool NcDim::operator==(const NcDim& rhs) const
 {
@@ -59,11 +42,6 @@ bool NcDim::operator!=(const NcDim & rhs) const
 NcGroup  NcDim::getParentGroup() const {
   return NcGroup(groupId);
 }
-
-// Constructor generates a null object.
-NcDim::NcDim() :
-  nullObject(true)
-{}
 
 // Constructor for a dimension (must already exist in the netCDF file.)
 NcDim::NcDim(const NcGroup& grp, int dimId) :

--- a/cxx4/ncDim.h
+++ b/cxx4/ncDim.h
@@ -13,12 +13,7 @@ namespace netCDF
   class NcDim   {
 
   public:
-
-    /*! destructor*/
-    ~NcDim(){};
-
-    /*! Constructor generates a \ref isNull "null object". */
-    NcDim ();
+    NcDim () = default;
 
     /*!
       Constructor for a dimension .
@@ -28,17 +23,11 @@ namespace netCDF
     */
     NcDim(const NcGroup& grp, int dimId);
 
-    /*! assignment operator  */
-    NcDim& operator =(const NcDim &);
-
     /*! equivalence operator */
     bool operator==(const NcDim& rhs) const;
 
     /*!  != operator */
     bool operator!=(const NcDim& rhs) const;
-
-    /*! The copy constructor. */
-    NcDim(const NcDim& ncDim);
 
     /*! The name of this dimension.*/
     std::string getName() const;
@@ -68,15 +57,10 @@ namespace netCDF
     friend bool operator>(const NcDim& lhs,const NcDim& rhs);
 
   private:
-
-    bool nullObject;
-
-    int myId;
-
-    int groupId;
-
+    bool nullObject{true};
+    int myId{-1};
+    int groupId{-1};
   };
-  
 }
 
 

--- a/cxx4/ncDouble.cpp
+++ b/cxx4/ncDouble.cpp
@@ -11,10 +11,6 @@ namespace netCDF {
 NcDouble::NcDouble() : NcType(NC_DOUBLE){
 }
 
-NcDouble::~NcDouble() {
-}
-
-
 // equivalence operator
 bool NcDouble::operator==(const NcDouble & rhs)    {
   // simply check the netCDF id.

--- a/cxx4/ncDouble.h
+++ b/cxx4/ncDouble.h
@@ -14,9 +14,6 @@ namespace netCDF
     /*! equivalence operator */
     bool operator==(const NcDouble & rhs);
     
-    /*!  destructor */
-    ~NcDouble();
-    
     /*! Constructor */
     NcDouble();
   };

--- a/cxx4/ncFile.cpp
+++ b/cxx4/ncFile.cpp
@@ -37,11 +37,6 @@ void NcFile::close()
   nullObject = true;
 }
 
-// Constructor generates a null object.
-NcFile::NcFile() :
-    NcGroup()  // invoke base class constructor
-{}
-
 // constructor
 NcFile::NcFile(const string& filePath, const FileMode fMode)
 {

--- a/cxx4/ncFile.h
+++ b/cxx4/ncFile.h
@@ -37,9 +37,22 @@ namespace netCDF
 
 
       /*! Constructor generates a \ref isNull "null object". */
-      NcFile();
+      NcFile() = default;
+      /*! Closes file and releases all resources */
+      ~NcFile() override;
 
-      /*!
+      /* Do not allow definition of NcFile involving copying any NcFile or NcGroup.
+         Because the destructor closes the file and releases al resources such
+         an action could leave NcFile objects in an invalid state */
+      NcFile& operator =(const NcGroup & rhs) = delete;
+      NcFile& operator =(const NcFile & rhs) = delete;
+      NcFile(const NcGroup& rhs) = delete;
+      NcFile(const NcFile& rhs) = delete;
+
+      NcFile& operator =(NcFile&& rhs) = delete;
+      NcFile(NcFile&& rhs) = delete;
+
+     /*!
         Opens a netCDF file.
         \param filePath    Name of netCDF optional path.
         \aram ncFileFlags File flags from netcdf.h
@@ -105,9 +118,6 @@ namespace netCDF
       //! Close a file before destructor call
       void close();
 
-      /*! destructor */
-      virtual ~NcFile(); //closes file and releases all resources
-
       //! Synchronize an open netcdf dataset to disk
       void sync();
 
@@ -119,16 +129,6 @@ namespace netCDF
 
       //! Leave define mode, used for classic model
       void enddef();
-
-
-   private:
-	   /* Do not allow definition of NcFile involving copying any NcFile or NcGroup.
-		  Because the destructor closes the file and releases al resources such
-		  an action could leave NcFile objects in an invalid state */
-	   NcFile& operator =(const NcGroup & rhs);
-	   NcFile& operator =(const NcFile & rhs);
-	   NcFile(const NcGroup& rhs);
-	   NcFile(const NcFile& rhs);
    };
 
 }

--- a/cxx4/ncFill.cpp
+++ b/cxx4/ncFill.cpp
@@ -19,10 +19,6 @@ fill values are written when you create non-record variables or when you write a
 beyond data that has not yet been written. */
 
 
-//NcFill constructor
-NcFill::~NcFill() {
-
-};
 void NcFill::set_Fill( int ncid, int fillmode, int *old_modep ) {
 
   ncCheck(nc_set_fill(ncid, fillmode, old_modep ),__FILE__,__LINE__);

--- a/cxx4/ncFill.h
+++ b/cxx4/ncFill.h
@@ -20,13 +20,7 @@ namespace netCDF
   class NcFill
     {
       public:
-        ~NcFill();
-
-        //constructor
-        NcFill();
-
-        //member function
-        void set_Fill(int, int, int*);
+        void set_Fill(int ncid, int fillmode, int* old_modep);
       };
 
 }

--- a/cxx4/ncFilter.cpp
+++ b/cxx4/ncFilter.cpp
@@ -9,11 +9,6 @@
 using namespace std;
 using namespace netCDF;
 
-// Constructor for filtering object
-NcFilter::~NcFilter() {
-
-};
-
 /* Define a new variable filter for either compression or decompression. The below
 method allows for setting of the filter which is to be used wen writing a variable. */
 void NcFilter::setFilter(unsigned int ncid, unsigned int varid, unsigned int filterId, size_t nparams, const unsigned int* parms)

--- a/cxx4/ncFilter.h
+++ b/cxx4/ncFilter.h
@@ -12,11 +12,6 @@ namespace netCDF
   class NcFilter
     {
       public:
-        ~NcFilter();
-
-        //constructor
-        NcFilter ();
-
         /* Member functions:
         setFilter: allows for filter definition of a variable when writing
         getFilter: querys about a filter (if any) associated with the variable

--- a/cxx4/ncFloat.cpp
+++ b/cxx4/ncFloat.cpp
@@ -11,10 +11,6 @@ namespace netCDF {
 NcFloat::NcFloat() : NcType(NC_FLOAT){
 }
 
-NcFloat::~NcFloat() {
-}
-
-
 // equivalence operator
 bool NcFloat::operator==(const NcFloat & rhs)    {
   // simply check the netCDF id.

--- a/cxx4/ncFloat.h
+++ b/cxx4/ncFloat.h
@@ -13,10 +13,6 @@ namespace netCDF
     
     /*! equivalence operator */
     bool operator==(const NcFloat & rhs);
-    
-    /*!  destructor */
-    ~NcFloat();
-    
     /*! Constructor */
     NcFloat();
   };

--- a/cxx4/ncGroup.cpp
+++ b/cxx4/ncGroup.cpp
@@ -42,38 +42,6 @@ using namespace netCDF;
 
 /////////////////////////////////////////////
 
-NcGroup::~NcGroup()
-{
-}
-
-// Constructor generates a null object.
-NcGroup::NcGroup() :
-  nullObject(true),
-  myId(-1)
-{}
-
-
-// constructor
-NcGroup::NcGroup(const int groupId) :
-  nullObject(false),
-  myId(groupId)
-{ }
-
-// assignment operator
-NcGroup& NcGroup::operator=(const NcGroup & rhs)
-{
-  nullObject = rhs.nullObject;
-  myId = rhs.myId;
-  return *this;
-}
-
-// The copy constructor.
-NcGroup::NcGroup(const NcGroup& rhs):
-  nullObject(rhs.nullObject),
-  myId(rhs.myId)
-{}
-
-
 // equivalence operator
 bool NcGroup::operator==(const NcGroup & rhs) const
 {

--- a/cxx4/ncGroup.h
+++ b/cxx4/ncGroup.h
@@ -55,21 +55,16 @@ namespace netCDF
 	All                 //!< Select from contents of current, parents and child groups.
       };
 
-
-    /*! assignment operator  */
-    NcGroup& operator=(const NcGroup& rhs);
+    //* constructor */
+    NcGroup(int groupId) : nullObject(false), myId(groupId) {}
 
     /*! Constructor generates a \ref isNull "null object". */
-    NcGroup();
-
-    //* constructor */
-    NcGroup(int groupId);
-
-    /*! The copy constructor. */
-    NcGroup(const NcGroup& rhs);
-
-    /*! destructor  */
-    virtual ~NcGroup();
+    NcGroup() = default;
+    virtual ~NcGroup() = default;
+    NcGroup(const NcGroup& rhs) = default;
+    NcGroup(NcGroup&& rhs) = default;
+    NcGroup& operator=(const NcGroup& rhs) = default;
+    NcGroup& operator=(NcGroup&& rhs) = default;
 
     /*! equivalence operator */
     bool operator==(const NcGroup& rhs) const;
@@ -563,14 +558,8 @@ namespace netCDF
 
 
   protected:
-
-    /*! assignment operator  */
-    /* NcGroup& operator=(const NcGroup& rhs); */
-
-    bool nullObject;
-
-    int myId;
-
+    bool nullObject{true};
+    int myId{-1};
   };
 
 }

--- a/cxx4/ncGroupAtt.cpp
+++ b/cxx4/ncGroupAtt.cpp
@@ -23,24 +23,6 @@ namespace netCDF {
 
 using namespace netCDF;
 
-// assignment operator
-NcGroupAtt& NcGroupAtt::operator=(const NcGroupAtt & rhs)
-{
-  NcAtt::operator=(rhs);    // assign base class parts
-  return *this;
-}
-
-//! The copy constructor.
-NcGroupAtt::NcGroupAtt(const NcGroupAtt& rhs): 
-  NcAtt(rhs)   // invoke base class copy constructor
-{}
-
-
-// Constructor generates a null object.
-NcGroupAtt::NcGroupAtt() : 
-  NcAtt()  // invoke base class constructor
-{}
-
 // equivalence operator (doesn't bother compaing varid's of each object).
 bool NcGroupAtt::operator==(const NcGroupAtt & rhs)
 {

--- a/cxx4/ncGroupAtt.h
+++ b/cxx4/ncGroupAtt.h
@@ -12,15 +12,11 @@ namespace netCDF
   class NcGroupAtt : public NcAtt
   {
   public:
-    
-    /*! assignment operator */
-    NcGroupAtt& operator= (const NcGroupAtt& rhs);
-   
-    /*! Constructor generates a \ref isNull "null object". */
-    NcGroupAtt ();
-    
-    /*! The copy constructor. */
-    NcGroupAtt(const NcGroupAtt& rhs) ;
+    NcGroupAtt () = default;
+    NcGroupAtt(const NcGroupAtt& rhs)  = default;
+    NcGroupAtt& operator= (const NcGroupAtt& rhs) = default;
+    NcGroupAtt(NcGroupAtt&& rhs)  = default;
+    NcGroupAtt& operator= (NcGroupAtt&& rhs) = default;
       
     /*! 
       Constructor for an existing global attribute.

--- a/cxx4/ncInt.cpp
+++ b/cxx4/ncInt.cpp
@@ -11,10 +11,6 @@ namespace netCDF {
 NcInt::NcInt() : NcType(NC_INT){
 }
 
-NcInt::~NcInt() {
-}
-
-
 // equivalence operator
 bool NcInt::operator==(const NcInt & rhs)    {
   // simply check the netCDF id.

--- a/cxx4/ncInt.h
+++ b/cxx4/ncInt.h
@@ -14,9 +14,6 @@ namespace netCDF
     /*! equivalence operator */
     bool operator==(const NcInt & rhs);
     
-    /*!  destructor */
-    ~NcInt();
-    
     /*! Constructor */
     NcInt();
   };

--- a/cxx4/ncInt64.cpp
+++ b/cxx4/ncInt64.cpp
@@ -11,10 +11,6 @@ namespace netCDF {
 NcInt64::NcInt64() : NcType(NC_INT64){
 }
 
-NcInt64::~NcInt64() {
-}
-
-
 // equivalence operator
 bool NcInt64::operator==(const NcInt64 & rhs)    {
   // simply check the netCDF id.

--- a/cxx4/ncInt64.h
+++ b/cxx4/ncInt64.h
@@ -14,9 +14,6 @@ namespace netCDF
     /*! equivalence operator */
     bool operator==(const NcInt64 & rhs);
     
-    /*!  destructor */
-    ~NcInt64();
-    
     /*! Constructor */
     NcInt64();
   };

--- a/cxx4/ncOpaqueType.cpp
+++ b/cxx4/ncOpaqueType.cpp
@@ -11,14 +11,6 @@ using namespace netCDF::exceptions;
 using namespace netCDF;
   
 // assignment operator
-NcOpaqueType& NcOpaqueType::operator=(const NcOpaqueType& rhs)
-{
-  // assign base class parts
-  NcType::operator=(rhs);    
-  return *this;
-}
-  
-// assignment operator
 NcOpaqueType& NcOpaqueType::operator=(const NcType& rhs)
 {
   if (&rhs != this) {
@@ -29,19 +21,6 @@ NcOpaqueType& NcOpaqueType::operator=(const NcType& rhs)
   }
   return *this;
 }
-
-// The copy constructor.
-NcOpaqueType::NcOpaqueType(const NcOpaqueType& rhs): 
-  NcType(rhs)
-{
-}
-
-
-// Constructor generates a null object.
-NcOpaqueType::NcOpaqueType() :
-  NcType()   // invoke base class constructor
-{}
-
 
 // constructor
 NcOpaqueType::NcOpaqueType(const NcGroup& grp, const string& name) :

--- a/cxx4/ncOpaqueType.h
+++ b/cxx4/ncOpaqueType.h
@@ -14,9 +14,12 @@ namespace netCDF
   class NcOpaqueType : public NcType
   {
   public:
-
-    /*! Constructor generates a \ref isNull "null object". */
-    NcOpaqueType();
+    NcOpaqueType() = default;
+    ~NcOpaqueType() = default;
+    NcOpaqueType(const NcOpaqueType& rhs) = default;
+    NcOpaqueType(NcOpaqueType&& rhs) = default;
+    NcOpaqueType& operator=(const NcOpaqueType& rhs) = default;
+    NcOpaqueType& operator=(NcOpaqueType&& rhs) = default;
 
     /*! 
       Constructor.
@@ -33,21 +36,12 @@ namespace netCDF
       \param ncType     A Nctype object.
     */
     NcOpaqueType(const NcType& ncType);
-
-    /*! assignment operator */
-    NcOpaqueType& operator=(const NcOpaqueType& rhs);
       
     /*! 
       Assignment operator.
       This assigns from the base type NcType object. Will throw an exception if the NcType is not the base of an Opaque type.
     */
     NcOpaqueType& operator=(const NcType& rhs);
-      
-    /*! The copy constructor.*/
-    NcOpaqueType(const NcOpaqueType& rhs);
-      
-    /*!  destructor */
-    ~NcOpaqueType(){;}
 
     /*! Returns the size of the opaque type in bytes. */
     size_t  getTypeSize() const;

--- a/cxx4/ncShort.cpp
+++ b/cxx4/ncShort.cpp
@@ -11,10 +11,6 @@ namespace netCDF {
 NcShort::NcShort() : NcType(NC_SHORT){
 }
 
-NcShort::~NcShort() {
-}
-
-
 // equivalence operator
 bool NcShort::operator==(const NcShort & rhs)    {
   // simply check the netCDF id.

--- a/cxx4/ncShort.h
+++ b/cxx4/ncShort.h
@@ -14,9 +14,6 @@ namespace netCDF
     /*! equivalence operator */
     bool operator==(const NcShort & rhs);
     
-    /*! destructor */
-    ~NcShort();
-    
     /*! Constructor */
     NcShort();
   };

--- a/cxx4/ncString.cpp
+++ b/cxx4/ncString.cpp
@@ -11,10 +11,6 @@ namespace netCDF {
 NcString::NcString() : NcType(NC_STRING){
 }
 
-NcString::~NcString() {
-}
-
-
 // equivalence operator
 bool NcString::operator==(const NcString & rhs)    {
   // simply check the netCDF id.

--- a/cxx4/ncString.h
+++ b/cxx4/ncString.h
@@ -14,9 +14,6 @@ namespace netCDF
     /*! equivalence operator */
     bool operator==(const NcString & rhs);
     
-    /*! destructor */
-    ~NcString();
-    
     /*! Constructor */
     NcString();
   };

--- a/cxx4/ncType.cpp
+++ b/cxx4/ncType.cpp
@@ -23,28 +23,6 @@ namespace netCDF {
 
 using namespace netCDF;
 
-// assignment operator
-NcType& NcType::operator=(const NcType & rhs)
-{
-  nullObject = rhs.nullObject;
-  myId= rhs.myId;
-  groupId = rhs.groupId;
-  return *this;
-}
-
-// The copy constructor.
-NcType::NcType(const NcType& rhs):
-  nullObject(rhs.nullObject),
-  myId(rhs.myId),
-  groupId(rhs.groupId)
-{}
-
-
-// Constructor generates a null object.
-NcType::NcType() :
-  nullObject(true)
-{}
-
 // constructor
 NcType::NcType(const NcGroup& grp, const string& name) :
   nullObject (false)
@@ -52,14 +30,6 @@ NcType::NcType(const NcGroup& grp, const string& name) :
   groupId= grp.getId();
   NcType typTmp(grp.getType(name,NcGroup::ParentsAndCurrent));
   myId = typTmp.getId();
-}
-
-// constructor for a global type
-NcType::NcType(nc_type id) :
-  nullObject(false),
-  myId(id),
-  groupId(0)
-{
 }
 
 // Constructor for a non-global type

--- a/cxx4/ncType.h
+++ b/cxx4/ncType.h
@@ -43,7 +43,13 @@ namespace netCDF
     };
 
     /*! Constructor generates a \ref isNull "null object". */
-    NcType();
+    NcType() = default;
+    NcType(const NcType& rhs) = default;
+    NcType(NcType&& rhs) = default;
+    NcType& operator=(const NcType& rhs) = default;
+    NcType& operator=(NcType&& rhs) = default;
+
+    virtual ~NcType() = default;
 
     /*!
       Constructor for a non-global type.
@@ -69,13 +75,7 @@ namespace netCDF
       This object describes the "essential" information for a netCDF global type.
       \param id     type id
     */
-    NcType(nc_type id);
-
-    /*! The copy constructor. */
-    NcType(const NcType& rhs);
-
-    /*! destructor  */
-    virtual ~NcType() {}
+    NcType(nc_type id) : nullObject(false), myId(id), groupId(0) {}
 
     /*! equivalence operator */
     bool operator==(const NcType&) const;
@@ -139,18 +139,13 @@ namespace netCDF
     friend bool operator>(const NcType& lhs,const NcType& rhs);
 
   protected:
-
-    /*! assignment operator  */
-    NcType& operator=(const NcType& rhs);
-
-    bool nullObject;
+    bool nullObject{true};
 
     /*! the type Id */
-    nc_type myId;
+    nc_type myId{-1};
 
     /*! the group Id */
-    int groupId;
+    int groupId{-1};
   };
-
 }
 #endif

--- a/cxx4/ncType.h
+++ b/cxx4/ncType.h
@@ -150,13 +150,6 @@ namespace netCDF
 
     /*! the group Id */
     int groupId;
-
-    /*! An ncid associated with a particular open file
-      (returned from nc_open).
-      This is required by many of the functions ncType uses,
-      such as nc_inq_type */
-    int g_fileId;
-
   };
 
 }

--- a/cxx4/ncUbyte.cpp
+++ b/cxx4/ncUbyte.cpp
@@ -11,10 +11,6 @@ namespace netCDF {
 NcUbyte::NcUbyte() : NcType(NC_UBYTE){
 }
 
-NcUbyte::~NcUbyte() {
-}
-
-
 // equivalence operator
 bool NcUbyte::operator==(const NcUbyte & rhs)    {
   // simply check the netCDF id.

--- a/cxx4/ncUbyte.h
+++ b/cxx4/ncUbyte.h
@@ -14,9 +14,6 @@ namespace netCDF
     /*! equivalence operator */
     bool operator==(const NcUbyte & rhs);
     
-    /*! destructor */
-    ~NcUbyte();
-    
     /*! Constructor */
     NcUbyte();
   };

--- a/cxx4/ncUint.cpp
+++ b/cxx4/ncUint.cpp
@@ -11,10 +11,6 @@ namespace netCDF {
 NcUint::NcUint() : NcType(NC_UINT){
 }
 
-NcUint::~NcUint() {
-}
-
-
 // equivalence operator
 bool NcUint::operator==(const NcUint & rhs)    {
   // simply check the netCDF id.

--- a/cxx4/ncUint.h
+++ b/cxx4/ncUint.h
@@ -14,9 +14,6 @@ namespace netCDF
     /*! equivalence operator */
     bool operator==(const NcUint & rhs);
     
-    /*! destructor */
-    ~NcUint();
-    
     /*! Constructor */
     NcUint();
   };

--- a/cxx4/ncUint64.cpp
+++ b/cxx4/ncUint64.cpp
@@ -11,10 +11,6 @@ namespace netCDF {
 NcUint64::NcUint64() : NcType(NC_UINT64){
 }
 
-NcUint64::~NcUint64() {
-}
-
-
 // equivalence operator
 bool NcUint64::operator==(const NcUint64 & rhs)    {
   // simply check the netCDF id.

--- a/cxx4/ncUint64.h
+++ b/cxx4/ncUint64.h
@@ -14,9 +14,6 @@ namespace netCDF
     /*! equivalence operator */
     bool operator==(const NcUint64 & rhs);
     
-    /*! destructor */
-    ~NcUint64();
-    
     /*! Constructor */
     NcUint64();
   };

--- a/cxx4/ncUshort.cpp
+++ b/cxx4/ncUshort.cpp
@@ -11,10 +11,6 @@ namespace netCDF {
 NcUshort::NcUshort() : NcType(NC_USHORT){
 }
 
-NcUshort::~NcUshort() {
-}
-
-
 // equivalence operator
 bool NcUshort::operator==(const NcUshort & rhs)    {
   // simply check the netCDF id.

--- a/cxx4/ncUshort.h
+++ b/cxx4/ncUshort.h
@@ -14,9 +14,6 @@ namespace netCDF
     /*! equivalence operator */
     bool operator==(const NcUshort & rhs);
     
-    /*! destructor */
-    ~NcUshort();
-    
     /*! Constructor */
     NcUshort();
   };

--- a/cxx4/ncVar.cpp
+++ b/cxx4/ncVar.cpp
@@ -26,22 +26,6 @@ namespace netCDF {
 
 using namespace netCDF;
 
-// assignment operator
-NcVar& NcVar::operator=(const NcVar & rhs)
-{
-  nullObject = rhs.nullObject;
-  myId = rhs.myId;
-  groupId = rhs.groupId;
-  return *this;
-}
-
-// The copy constructor.
-NcVar::NcVar(const NcVar& rhs) :
-  nullObject(rhs.nullObject),
-  myId(rhs.myId),
-  groupId(rhs.groupId)
-{}
-
 
 // equivalence operator
 bool NcVar::operator==(const NcVar & rhs) const
@@ -61,21 +45,6 @@ bool NcVar::operator!=(const NcVar & rhs) const
 // Constructors and intialization
 
 /////////////////
-
-// Constructor generates a null object.
-NcVar::NcVar() : nullObject(true),
-                 myId(-1),
-                 groupId(-1)
-{}
-
-// Constructor for a variable (must already exist in the netCDF file.)
-NcVar::NcVar (const NcGroup& grp, const int& varId) :
-  nullObject (false),
-  myId (varId),
-  groupId(grp.getId())
-{}
-
-
 
 // Gets parent group.
 NcGroup  NcVar::getParentGroup() const {

--- a/cxx4/ncVar.h
+++ b/cxx4/ncVar.h
@@ -65,11 +65,8 @@ namespace netCDF
       nc_FLETCHER32 = NC_FLETCHER32  //!< Selects the Fletcher32 checksum filter.
       };
 
-    /*! destructor */
-    ~NcVar(){};
-
     /*! Constructor generates a \ref isNull "null object". */
-    NcVar ();
+    NcVar () = default;
 
     /*! Constructor for a variable .
 
@@ -77,19 +74,17 @@ namespace netCDF
       \param grp    Parent NcGroup object.
       \param varId  Id of the is NcVar object.
     */
-    NcVar (const NcGroup& grp, const int& varId);
-
-    /*! assignment operator  */
-    NcVar& operator =(const NcVar& rhs);
+    NcVar (const NcGroup& grp, const int& varId) :
+      nullObject (false),
+      myId (varId),
+      groupId(grp.getId()
+    ) {}
 
     /*! equivalence operator */
     bool operator==(const NcVar& rhs) const;
 
     /*!  != operator */
     bool operator!=(const NcVar& rhs) const;
-
-    /*! The copy constructor. */
-    NcVar(const NcVar& ncVar);
 
     /*! Name of this NcVar object.*/
     std::string getName() const;
@@ -99,7 +94,6 @@ namespace netCDF
 
     /*! Returns the variable type. */
     NcType getType() const;
-
 
     /*! Rename the variable. */
     void rename( const std::string& newname ) const;
@@ -1131,21 +1125,11 @@ namespace netCDF
 */
     void putVar(const std::vector<size_t>& startp, const std::vector<size_t>& countp, const std::vector<ptrdiff_t>& stridep, const std::vector<ptrdiff_t>& imapp, const long long* dataValues) const;
 
-
-
   private:
-
-    bool nullObject;
-
-    int myId;
-
-    int groupId;
-
+    bool nullObject {true};
+    int myId {-1};
+    int groupId {-1};
   };
-
-
 }
-
-
 
 #endif

--- a/cxx4/ncVlenType.cpp
+++ b/cxx4/ncVlenType.cpp
@@ -23,13 +23,6 @@ using namespace netCDF::exceptions;
 using namespace netCDF;
 
 // assignment operator
-NcVlenType& NcVlenType::operator=(const NcVlenType& rhs)
-{
-  NcType::operator=(rhs);    // assign base class parts
-  return *this;
-}
-
-// assignment operator
 NcVlenType& NcVlenType::operator=(const NcType& rhs)
 {
   if (&rhs != this) {
@@ -40,18 +33,6 @@ NcVlenType& NcVlenType::operator=(const NcType& rhs)
   }
   return *this;
 }
-
-// The copy constructor.
-NcVlenType::NcVlenType(const NcVlenType& rhs):   
-  NcType(rhs)
-{
-}
-
-
-// Constructor generates a null object.
-NcVlenType::NcVlenType() :
-  NcType()   // invoke base class constructor
-{}
 
 // constructor
 NcVlenType::NcVlenType(const NcGroup& grp, const string& name) :

--- a/cxx4/ncVlenType.h
+++ b/cxx4/ncVlenType.h
@@ -14,9 +14,12 @@ namespace netCDF
   class NcVlenType : public NcType
   {
   public:
-
-    /*! Constructor generates a \ref isNull "null object". */
-    NcVlenType();
+    NcVlenType() = default;
+    NcVlenType(const NcVlenType& rhs) = default;
+    NcVlenType(NcVlenType&& rhs) = default;
+    NcVlenType& operator=(const NcVlenType& rhs) = default;
+    NcVlenType& operator=(NcVlenType&& rhs) = default;
+    ~NcVlenType() = default;
 
     /*! 
       Constructor.
@@ -33,24 +36,14 @@ namespace netCDF
       \param ncType     A Nctype object.
     */
     NcVlenType(const NcType& ncType);
-
-    /*! assignment operator */
-    NcVlenType& operator=(const NcVlenType& rhs);
       
     /*! 
       Assignment operator.
       This assigns from the base type NcType object. Will throw an exception if the NcType is not the base of a Vlen type.
     */
     NcVlenType& operator=(const NcType& rhs);
-      
-    /*! The copy constructor. */
-    NcVlenType(const NcVlenType& rhs);
-      
-    ~NcVlenType(){;}
-      
     /*! Returns the base type. */
     NcType  getBaseType() const;
-      
   };
   
 }

--- a/cxx4/test_classic.cpp
+++ b/cxx4/test_classic.cpp
@@ -16,9 +16,9 @@ int main()
       cout << "Test creation of classic format file" << endl;
       {
 	 NcFile ncFile("test_classic.nc", NcFile::replace, NcFile::classic);
-	 NcDim dim1 = ncFile.addDim("dim1",11);
-	 NcDim dim2 = ncFile.addDim("dim2");
-	 NcDim dim3 = ncFile.addDim("dim3",13);
+	 [[maybe_unused]] NcDim dim1 = ncFile.addDim("dim1",11);
+	 [[maybe_unused]] NcDim dim2 = ncFile.addDim("dim2");
+	 [[maybe_unused]] NcDim dim3 = ncFile.addDim("dim3",13);
 
 	 NcVar var_gw  = ncFile.addVar("George_Washington", ncInt, dim1);
 	 // The following fails, I don't know why...

--- a/cxx4/test_dim.cpp
+++ b/cxx4/test_dim.cpp
@@ -39,8 +39,8 @@ int main()
 
       cout <<left<<setw(55)<<"Testing addVar(\"dimensionName\")";
       // Coordinate variables
-      NcVar var1 = ncFile.addVar("dim1", NcInt{});
-      NcVar var4 = groupB.addVar("dim4", NcInt{});
+      ncFile.addVar("dim1", NcInt{});
+      groupB.addVar("dim4", NcInt{});
       cout <<"    -----------   passed\n";
 
       cout <<left<<setw(55)<<"Testing NcDim::isUnlimited()";

--- a/cxx4/test_var.cpp
+++ b/cxx4/test_var.cpp
@@ -30,42 +30,42 @@ int main()
 	cout <<"    -----------   passed\n";
 
 	cout <<left<<setw(55)<<"Testing addVar(\"varName\",\"typeName\")";
-	NcVar var_scalar  = ncFile.addVar("var_scalar",ncByte);
+	ncFile.addVar("var_scalar",ncByte);
 	cout <<"    -----------   passed\n";
 
 	cout <<left<<setw(55)<<"Testing addDim(\"dimensionName\")";
-	NcDim dim1 = ncFile.addDim("dim1",11);
-	NcDim dim2 = ncFile.addDim("dim2");
-	NcDim dim3 = ncFile.addDim("dim3",13);
-	NcDim dim4 = groupB.addDim("dim4",14);
-	NcDim dim5 = groupB.addDim("dim5",15);
-	NcDim dim6 = groupB.addDim("dim6",16);
-	NcDim dim7 = groupB.addDim("dim7",17);
+	[[maybe_unused]] NcDim dim1 = ncFile.addDim("dim1",11);
+	[[maybe_unused]] NcDim dim2 = ncFile.addDim("dim2");
+	[[maybe_unused]] NcDim dim3 = ncFile.addDim("dim3",13);
+	[[maybe_unused]] NcDim dim4 = groupB.addDim("dim4",14);
+	[[maybe_unused]] NcDim dim5 = groupB.addDim("dim5",15);
+	[[maybe_unused]] NcDim dim6 = groupB.addDim("dim6",16);
+	[[maybe_unused]] NcDim dim7 = groupB.addDim("dim7",17);
 	cout <<"    -----------   passed\n";
 
 	cout <<left<<setw(55)<<"Testing addVar(\"varName\",\"typeName\",\"dimName\")";
 
-	NcVar varA1_1  = ncFile.addVar("varA1_1",ncByte,dim1);
-	NcVar varA1_2  = ncFile.addVar("varA1_2","byte","dim1");
+	ncFile.addVar("varA1_1",ncByte,dim1);
+	ncFile.addVar("varA1_2","byte","dim1");
 	vector<NcDim> dimArray(2);
 	dimArray[0]=dim1;
 	dimArray[1]=dim2;
 	vector<string> stringArray(2);
 	stringArray[0] = "dim1";
 	stringArray[1] = "dim2";
-	NcVar varA1_3  = ncFile.addVar("varA1_3",ncByte,dimArray);
-	NcVar varA1_4  = ncFile.addVar("varA1_4","byte",stringArray);
+	ncFile.addVar("varA1_3",ncByte,dimArray);
+	ncFile.addVar("varA1_4","byte",stringArray);
 
-	NcVar varA1_5  = groupB.addVar("varA1_5",ncByte,dim4);
-	NcVar varA1_6  = groupB.addVar("varA1_6",ncByte,dim2);
+	groupB.addVar("varA1_5",ncByte,dim4);
+	groupB.addVar("varA1_6",ncByte,dim2);
 
 	dimArray[0]=dim1;
 	dimArray[1]=dim7;
-	NcVar varA1_7  = groupB.addVar("varA1_7",ncByte,dimArray);
+	groupB.addVar("varA1_7",ncByte,dimArray);
 
 	dimArray[0]=dim1;
 	dimArray[1]=dim2;
-	NcVar varA1_8  = groupC.addVar("varA1_8",ncByte,dimArray);
+	groupC.addVar("varA1_8",ncByte,dimArray);
 	cout <<"    -----------   passed\n";
       }
 
@@ -79,30 +79,30 @@ int main()
       NcGroup groupB(groupA.addGroup("groupB"));
       NcGroup groupC(groupA.addGroup("groupC"));
 
-      NcDim dim1 = ncFile.addDim("dim1",11);
-      NcDim dim2 = ncFile.addDim("dim2");
-      NcDim dim3 = ncFile.addDim("dim3",13);
-      NcDim dim4 = groupB.addDim("dim4",14);
-      NcDim dim5 = groupB.addDim("dim5",15);
-      NcDim dim6 = groupB.addDim("dim6",16);
-      NcDim dim7 = groupB.addDim("dim7",17);
+      [[maybe_unused]] NcDim dim1 = ncFile.addDim("dim1",11);
+      [[maybe_unused]] NcDim dim2 = ncFile.addDim("dim2");
+      [[maybe_unused]] NcDim dim3 = ncFile.addDim("dim3",13);
+      [[maybe_unused]] NcDim dim4 = groupB.addDim("dim4",14);
+      [[maybe_unused]] NcDim dim5 = groupB.addDim("dim5",15);
+      [[maybe_unused]] NcDim dim6 = groupB.addDim("dim6",16);
+      [[maybe_unused]] NcDim dim7 = groupB.addDim("dim7",17);
 
 
-      NcVar var_1   = ncFile.addVar("var_1",   ncByte,dim1);
-      NcVar varA_1  = groupA.addVar("varA_1",  ncByte,dim1);
-      NcVar varA_2  = groupA.addVar("varA_2",  ncByte,dim1);
-      NcVar varA0_1 = groupA0.addVar("varA0_1",ncByte,dim1);
-      NcVar varA0_2 = groupA0.addVar("varA0_2",ncByte,dim1);
-      NcVar varA0_3 = groupA0.addVar("varA0_3",ncByte,dim1);
-      NcVar varB_1  = groupB.addVar("varB_1",  ncByte,dim1);
-      NcVar varB_2  = groupB.addVar("varB_2",  ncByte,dim1);
-      NcVar varB_3  = groupB.addVar("varB_3",  ncByte,dim1);
-      NcVar varB_4  = groupB.addVar("varB_4",  ncByte,dim1);
-      NcVar varC_1  = groupC.addVar("varC_1",  ncByte,dim1);
-      NcVar varC_2  = groupC.addVar("varC_2",  ncByte,dim1);
-      NcVar varC_3  = groupC.addVar("varC_3",  ncByte,dim1);
-      NcVar varC_4  = groupC.addVar("varC_4",  ncByte,dim1);
-      NcVar varC_5  = groupC.addVar("varC_5",  ncByte,dim1);
+      [[maybe_unused]] NcVar var_1   = ncFile.addVar("var_1",   ncByte,dim1);
+      [[maybe_unused]] NcVar varA_1  = groupA.addVar("varA_1",  ncByte,dim1);
+      [[maybe_unused]] NcVar varA_2  = groupA.addVar("varA_2",  ncByte,dim1);
+      [[maybe_unused]] NcVar varA0_1 = groupA0.addVar("varA0_1",ncByte,dim1);
+      [[maybe_unused]] NcVar varA0_2 = groupA0.addVar("varA0_2",ncByte,dim1);
+      [[maybe_unused]] NcVar varA0_3 = groupA0.addVar("varA0_3",ncByte,dim1);
+      [[maybe_unused]] NcVar varB_1  = groupB.addVar("varB_1",  ncByte,dim1);
+      [[maybe_unused]] NcVar varB_2  = groupB.addVar("varB_2",  ncByte,dim1);
+      [[maybe_unused]] NcVar varB_3  = groupB.addVar("varB_3",  ncByte,dim1);
+      [[maybe_unused]] NcVar varB_4  = groupB.addVar("varB_4",  ncByte,dim1);
+      [[maybe_unused]] NcVar varC_1  = groupC.addVar("varC_1",  ncByte,dim1);
+      [[maybe_unused]] NcVar varC_2  = groupC.addVar("varC_2",  ncByte,dim1);
+      [[maybe_unused]] NcVar varC_3  = groupC.addVar("varC_3",  ncByte,dim1);
+      [[maybe_unused]] NcVar varC_4  = groupC.addVar("varC_4",  ncByte,dim1);
+      [[maybe_unused]] NcVar varC_5  = groupC.addVar("varC_5",  ncByte,dim1);
 
       {
 	cout <<left<<setw(55)<<"Testing addCount([netCDF::Location])";

--- a/cxx4/test_var2.cpp
+++ b/cxx4/test_var2.cpp
@@ -25,38 +25,37 @@ int main()
       NcGroup groupB(groupA.addGroup("groupB"));
       NcGroup groupC(groupA.addGroup("groupC"));
 
-      NcDim dim1 = ncFile.addDim("dim1",10);
-      NcDim dim2 = ncFile.addDim("dim2");
-      NcDim dim3 = ncFile.addDim("dim3",13);
-      NcDim dim4 = groupB.addDim("dim4",14);
-      NcDim dim5 = groupB.addDim("dim5",15);
-      NcDim dim6 = groupB.addDim("dim6",16);
-      NcDim dim7 = groupB.addDim("dim7",17);
+      [[maybe_unused]] NcDim dim1 = ncFile.addDim("dim1",10);
+      [[maybe_unused]] NcDim dim2 = ncFile.addDim("dim2");
+      [[maybe_unused]] NcDim dim3 = ncFile.addDim("dim3",13);
+      [[maybe_unused]] NcDim dim4 = groupB.addDim("dim4",14);
+      [[maybe_unused]] NcDim dim5 = groupB.addDim("dim5",15);
+      [[maybe_unused]] NcDim dim6 = groupB.addDim("dim6",16);
+      [[maybe_unused]] NcDim dim7 = groupB.addDim("dim7",17);
 
-
-      NcVar var_1   = ncFile.addVar("var_1",   ncInt,dim1);
-      NcVar var_2   = ncFile.addVar("var_2",   ncInt,dim1);
-      NcVar var_3   = ncFile.addVar("var_3",   ncInt,dim1);
-      NcVar var_4   = ncFile.addVar("var_4",   ncInt,dim1);
-      NcVar var_5   = ncFile.addVar("var_5",   ncInt,dim1);
-      NcVar var_6   = ncFile.addVar("var_6",   ncInt,dim1);
-      NcVar var_7   = ncFile.addVar("var_7",   ncInt,dim1);
-      NcVar var_8   = ncFile.addVar("var_8",   ncInt,dim1);
-      NcVar var_9   = ncFile.addVar("var_9",   ncInt,dim1);
-      NcVar varA_1  = groupA.addVar("varA_1",  ncByte,dim1);
-      NcVar varA_2  = groupA.addVar("varA_2",  ncByte,dim1);
-      NcVar varA0_1 = groupA0.addVar("varA0_1",ncByte,dim1);
-      NcVar varA0_2 = groupA0.addVar("varA0_2",ncByte,dim1);
-      NcVar varA0_3 = groupA0.addVar("varA0_3",ncByte,dim1);
-      NcVar varB_1  = groupB.addVar("varB_1",  ncByte,dim1);
-      NcVar varB_2  = groupB.addVar("varB_2",  ncByte,dim1);
-      NcVar varB_3  = groupB.addVar("varB_3",  ncByte,dim1);
-      NcVar varB_4  = groupB.addVar("varB_4",  ncByte,dim1);
-      NcVar varC_1  = groupC.addVar("varC_1",  ncByte,dim1);
-      NcVar varC_2  = groupC.addVar("varC_2",  ncByte,dim1);
-      NcVar varC_3  = groupC.addVar("varC_3",  ncByte,dim1);
-      NcVar varC_4  = groupC.addVar("varC_4",  ncByte,dim1);
-      NcVar varC_5  = groupC.addVar("varC_5",  ncByte,dim1);
+      [[maybe_unused]] NcVar var_1   = ncFile.addVar("var_1",   ncInt,dim1);
+      [[maybe_unused]] NcVar var_2   = ncFile.addVar("var_2",   ncInt,dim1);
+      [[maybe_unused]] NcVar var_3   = ncFile.addVar("var_3",   ncInt,dim1);
+      [[maybe_unused]] NcVar var_4   = ncFile.addVar("var_4",   ncInt,dim1);
+      [[maybe_unused]] NcVar var_5   = ncFile.addVar("var_5",   ncInt,dim1);
+      [[maybe_unused]] NcVar var_6   = ncFile.addVar("var_6",   ncInt,dim1);
+      [[maybe_unused]] NcVar var_7   = ncFile.addVar("var_7",   ncInt,dim1);
+      [[maybe_unused]] NcVar var_8   = ncFile.addVar("var_8",   ncInt,dim1);
+      [[maybe_unused]] NcVar var_9   = ncFile.addVar("var_9",   ncInt,dim1);
+      [[maybe_unused]] NcVar varA_1  = groupA.addVar("varA_1",  ncByte,dim1);
+      [[maybe_unused]] NcVar varA_2  = groupA.addVar("varA_2",  ncByte,dim1);
+      [[maybe_unused]] NcVar varA0_1 = groupA0.addVar("varA0_1",ncByte,dim1);
+      [[maybe_unused]] NcVar varA0_2 = groupA0.addVar("varA0_2",ncByte,dim1);
+      [[maybe_unused]] NcVar varA0_3 = groupA0.addVar("varA0_3",ncByte,dim1);
+      [[maybe_unused]] NcVar varB_1  = groupB.addVar("varB_1",  ncByte,dim1);
+      [[maybe_unused]] NcVar varB_2  = groupB.addVar("varB_2",  ncByte,dim1);
+      [[maybe_unused]] NcVar varB_3  = groupB.addVar("varB_3",  ncByte,dim1);
+      [[maybe_unused]] NcVar varB_4  = groupB.addVar("varB_4",  ncByte,dim1);
+      [[maybe_unused]] NcVar varC_1  = groupC.addVar("varC_1",  ncByte,dim1);
+      [[maybe_unused]] NcVar varC_2  = groupC.addVar("varC_2",  ncByte,dim1);
+      [[maybe_unused]] NcVar varC_3  = groupC.addVar("varC_3",  ncByte,dim1);
+      [[maybe_unused]] NcVar varC_4  = groupC.addVar("varC_4",  ncByte,dim1);
+      [[maybe_unused]] NcVar varC_5  = groupC.addVar("varC_5",  ncByte,dim1);
 
 
       vector<short>  a1(10),b1(10);


### PR DESCRIPTION
See following C++ Core Guidelines for rationale:

- https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c20-if-you-can-avoid-defining-default-operations-do
- https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c21-if-you-define-or-delete-any-copy-move-or-destructor-function-define-or-delete-them-all

Basically we can rely on the compiler to generate all of these for us. This PR is net -400 lines and does exactly the same thing.