### PR TITLE
Remove global `g_ncid`

### DIFF
--- a/cxx4/ncFile.cpp
+++ b/cxx4/ncFile.cpp
@@ -9,8 +9,6 @@ using namespace std;
 using namespace netCDF;
 using namespace netCDF::exceptions;
 
-int g_ncid = -1;
-
 // destructor
 NcFile::~NcFile()
 {
@@ -31,7 +29,6 @@ void NcFile::close()
 {
   if (!nullObject) {
     ncCheck(nc_close(myId),__FILE__,__LINE__);
-    g_ncid = -1;
   }
 
   nullObject = true;
@@ -65,7 +62,6 @@ void NcFile::open(const string& filePath, int ncFileFlags) {
     close();
 
   ncCheck(nc_open(filePath.c_str(), ncFileFlags, &myId),__FILE__,__LINE__);
-  g_ncid = myId;
 
   nullObject=false;
 }
@@ -95,7 +91,6 @@ void NcFile::open(const string& filePath, const FileMode fMode)
       break;
     }
 
-  g_ncid = myId;
 
   nullObject=false;
 }
@@ -117,7 +112,6 @@ void NcFile::create(const string& filePath, const int ncFileFlags) {
 
   ncCheck(nc_create(filePath.c_str(),ncFileFlags,&myId),__FILE__,__LINE__);
 
-  g_ncid = myId;
 
   nullObject=false;
 }
@@ -159,7 +153,6 @@ void NcFile::open(const string& filePath, const FileMode fMode, const FileFormat
       break;
     }
 
-  g_ncid = myId;
   nullObject=false;
 }
 

--- a/cxx4/ncType.cpp
+++ b/cxx4/ncType.cpp
@@ -4,7 +4,6 @@
 #include "ncCheck.h"
 using namespace std;
 
-extern int g_ncid;
 
 namespace netCDF {
   //  Global comparator operator ==============
@@ -95,11 +94,7 @@ string  NcType::getName() const{
   char charName[NC_MAX_NAME+1];
   size_t *sizep=NULL;
 
-  /* We cannot call nc_inq_type without a valid
-     netcdf file ID (ncid), which is not *groupid*.
-     Working around this for now. */
-
-  ncCheck(nc_inq_type(g_ncid,myId,charName,sizep),__FILE__,__LINE__);
+  ncCheck(nc_inq_type(groupId,myId,charName,sizep),__FILE__,__LINE__);
   return string(charName);
 
 };
@@ -108,7 +103,7 @@ string  NcType::getName() const{
 size_t NcType::getSize() const{
   char* charName=NULL;
   size_t sizep;
-  ncCheck(nc_inq_type(g_ncid,myId,charName,&sizep),__FILE__,__LINE__);
+  ncCheck(nc_inq_type(groupId,myId,charName,&sizep),__FILE__,__LINE__);
   return sizep;
 };
 

--- a/cxx4/test_type.cpp
+++ b/cxx4/test_type.cpp
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 #include <stddef.h>
+#include <type_traits>
 #include "test_utilities.h"
 using namespace std;
 using namespace netCDF;
@@ -553,6 +554,22 @@ try
     cout <<"    -----------   passed\n";
 
 
+    {
+      // Test for issue 30/32
+      cout<<left<<std::setw(57)<<"Testing NcType::getName() with two open files";
+      NcFile nc4_file("nc4_format.cdf", NcFile::replace, NcFile::nc4);
+      NcFile classic_file("classic_format.cdf", NcFile::replace, NcFile::classic);
+
+      nc4_file.addVar("int64", ncInt64);
+
+      struct struct11 {
+        int mem1;
+      };
+      const auto compound_type11 = nc4_file.addCompoundType("struct11", sizeof(struct11));
+      const auto name = compound_type11.getName();
+      if (name != "struct11") throw NcException("Wrong name for compound type", __FILE__, __LINE__);
+    }
+    cout <<"    -----------   passed\n";
 
 }
 catch (NcException& e)


### PR DESCRIPTION
Closes #30
Fixes #32

Global file ID is no longer needed now that `nc_inq_type` can take a group ID (valid since netCDF-C 4.4.1).

Includes test that fails without this change.