### PR TITLE
remove unused file_id, avoid compiler warnings

### DIFF
--- a/cxx4/ncGroup.h
+++ b/cxx4/ncGroup.h
@@ -15,8 +15,6 @@
 namespace netCDF
 {
 
-  static int file_id;
-
   class NcVar;          // forward declaration.
   class NcDim;          // forward declaration.
   class NcVlenType;     // forward declaration.


### PR DESCRIPTION
Fix issue #85 and issue #105.  This looks like an easy fix of course, but I thought a pull request might make it even easier.