### PR TITLE
Mark NcException::what() as override for std::exception::what()

### DIFF
--- a/cxx4/ncException.h
+++ b/cxx4/ncException.h
@@ -29,7 +29,7 @@ namespace netCDF
       NcException(const NcException& e) throw();
       NcException& operator=(const NcException& e) throw();
       virtual ~NcException() throw();
-      const char* what() const throw();
+      const char* what() const throw() override;
       int errorCode() const throw();
     private:
       std::string* what_msg;


### PR DESCRIPTION
When building with GCC's flag `-Wsuggest-override`, this was called out as missing.