### PR TITLE
Add NcFile::getPath()

### DIFF
--- a/cxx4/ncFile.cpp
+++ b/cxx4/ncFile.cpp
@@ -176,15 +176,15 @@ void NcFile::enddef() {
     ncCheck(nc_enddef(myId),__FILE__,__LINE__);
 }
 
-std::string NcFile::getFilePath() const
+string NcFile::getFilePath() const
 {
-    std::size_t filePathLength;
-    nc_inq_path(getId(), &filePathLength, nullptr);
+    size_t filePathLength;
+    nc_inq_path(myId, &filePathLength, nullptr);
 
     char *filePathCString = new char[filePathLength + 1];
-    nc_inq_path(getId(), nullptr, filePathCString);
+    nc_inq_path(myId, nullptr, filePathCString);
 
-    std::string filePath {filePathCString};
+    string filePath {filePathCString};
     delete[] filePathCString;
 
     return filePath;

--- a/cxx4/ncFile.cpp
+++ b/cxx4/ncFile.cpp
@@ -176,7 +176,7 @@ void NcFile::enddef() {
     ncCheck(nc_enddef(myId),__FILE__,__LINE__);
 }
 
-string NcFile::getFilePath() const
+string NcFile::getPath() const
 {
     size_t filePathLength;
     nc_inq_path(myId, &filePathLength, nullptr);

--- a/cxx4/ncFile.cpp
+++ b/cxx4/ncFile.cpp
@@ -175,3 +175,17 @@ void NcFile::redef(){
 void NcFile::enddef() {
     ncCheck(nc_enddef(myId),__FILE__,__LINE__);
 }
+
+std::string NcFile::getFilePath() const
+{
+    std::size_t filePathLength;
+    nc_inq_path(getId(), &filePathLength, nullptr);
+
+    char *filePathCString = new char[filePathLength + 1];
+    nc_inq_path(getId(), nullptr, filePathCString);
+
+    std::string filePath {filePathCString};
+    delete[] filePathCString;
+
+    return filePath;
+}

--- a/cxx4/ncFile.cpp
+++ b/cxx4/ncFile.cpp
@@ -5,6 +5,7 @@
 #include<iostream>
 #include<string>
 #include<sstream>
+#include<vector>
 using namespace std;
 using namespace netCDF;
 using namespace netCDF::exceptions;
@@ -179,13 +180,10 @@ void NcFile::enddef() {
 string NcFile::getPath() const
 {
     size_t pathLength;
-    nc_inq_path(myId, &pathLength, nullptr);
+    ncCheck(nc_inq_path(myId, &pathLength, nullptr),__FILE__,__LINE__);
 
-    char *pathCString = new char[pathLength + 1];
-    nc_inq_path(myId, nullptr, pathCString);
+    vector<char> pathCString(pathLength + 1);
+    ncCheck(nc_inq_path(myId, nullptr, pathCString.data()),__FILE__,__LINE__);
 
-    string path (pathCString);
-    delete[] pathCString;
-
-    return path;
+    return string(pathCString.data());
 }

--- a/cxx4/ncFile.cpp
+++ b/cxx4/ncFile.cpp
@@ -180,10 +180,10 @@ void NcFile::enddef() {
 string NcFile::getPath() const
 {
     size_t pathLength;
-    ncCheck(nc_inq_path(myId, &pathLength, nullptr),__FILE__,__LINE__);
+    ncCheck(nc_inq_path(myId, &pathLength, NULL),__FILE__,__LINE__);
 
     vector<char> pathCString(pathLength + 1);
-    ncCheck(nc_inq_path(myId, nullptr, pathCString.data()),__FILE__,__LINE__);
+    ncCheck(nc_inq_path(myId, NULL, pathCString.data()),__FILE__,__LINE__);
 
     return string(pathCString.data());
 }

--- a/cxx4/ncFile.cpp
+++ b/cxx4/ncFile.cpp
@@ -178,14 +178,14 @@ void NcFile::enddef() {
 
 string NcFile::getPath() const
 {
-    size_t filePathLength;
-    nc_inq_path(myId, &filePathLength, nullptr);
+    size_t pathLength;
+    nc_inq_path(myId, &pathLength, nullptr);
 
-    char *filePathCString = new char[filePathLength + 1];
-    nc_inq_path(myId, nullptr, filePathCString);
+    char *pathCString = new char[pathLength + 1];
+    nc_inq_path(myId, nullptr, pathCString);
 
-    string filePath {filePathCString};
-    delete[] filePathCString;
+    string path (pathCString);
+    delete[] pathCString;
 
-    return filePath;
+    return path;
 }

--- a/cxx4/ncFile.h
+++ b/cxx4/ncFile.h
@@ -120,7 +120,7 @@ namespace netCDF
       //! Leave define mode, used for classic model
       void enddef();
 
-      std::string getFilePath() const;
+      std::string getPath() const;
 
 
    private:

--- a/cxx4/ncFile.h
+++ b/cxx4/ncFile.h
@@ -120,6 +120,8 @@ namespace netCDF
       //! Leave define mode, used for classic model
       void enddef();
 
+      std::string getFilePath() const;
+
 
    private:
 	   /* Do not allow definition of NcFile involving copying any NcFile or NcGroup.

--- a/cxx4/test_open_close.cpp
+++ b/cxx4/test_open_close.cpp
@@ -31,18 +31,28 @@ int main() {
       cout << "Caught Expected Exception." << endl;
     }
 
+    const char *fileName = "firstFile.cdf";
     // Test opening a file that exists.
-    cout << "Opening file \"firstFile.cdf\"... ";
+    cout << "Opening file \"" << fileName << "\"... ";
     try {
-      file.open("firstFile.cdf",NcFile::replace);
+      file.open(fileName,NcFile::replace);
       cout << "Success." << endl;
     } catch(NcException &e) {
       cout << "Caught unexpected exception." << endl;
       return e.errorCode();
     }
 
+    // Test retrieving path from file object.
+    cout << "Retrieving path from file object... ";
+    if (file.getPath() == fileName) {
+      cout << "Success." << endl;
+    } else {
+      cout << "Retrieved file path did not match input filename." << endl;
+      return -1;
+    }
+
     // Test closing a valid file.
-    cout << "Closing file...";
+    cout << "Closing file... ";
     try {
       file.close();
       cout << "Success." << endl;


### PR DESCRIPTION
The new NcFile method calls nc_inq_path() from the C library twice.

The first call retrieves the path length to create a correctly sized C string. The second call copies the path to the C string.

The C string gets copied to a standard string before getting deallocated, and the standard string gets returned.

The method does not modify the object.

A test for the new method appears in test_open_close.cpp between the opening and closing of the test file.